### PR TITLE
make AlignToVideo sensible with tolerance=0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 For binaries and general information see [the homepage](http://www.aegisub.org) and [release page](https://github.com/wangqr/Aegisub/releases).
 
-The bug tracker can be found at https://github.com/wagqr/Aegisub/issues .
+The bug tracker can be found at https://github.com/wangqr/Aegisub/issues .
 
 If you want to test the upstream version, r8942 [can be downloaded here](http://www.plorkyeran.com/aegisub/). If both r8942 and this fork have some common issue, report at [upstream](https://github.com/Aegisub/Aegisub/issues) may let more people see your issue, and I am also watching the upstream for issues. If it is a wangqr fork specific issue, report it here.
 

--- a/po/aegisub.pot
+++ b/po/aegisub.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.3+\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2005-2020-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2599,19 +2599,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/ar.po
+++ b/po/ar.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2013-07-22 14:32+0300\n"
 "Last-Translator: safa\n"
 "Language-Team: Arabic <kde-i18n-doc@kde.org>\n"
@@ -2807,19 +2807,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/be.po
+++ b/po/be.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub (unofficial)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2018-09-26 07:39+0000\n"
 "Last-Translator: Viktar Lieškievič <vityay.leshkevich@yandex.ru>, 2019\n"
 "Language-Team: Belarusian (https://www.transifex.com/byplay/teams/91944/"
@@ -2768,19 +2768,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/bg.po
+++ b/po/bg.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-01-29 21:10+0200\n"
 "Last-Translator: Igor Urazov <z0rc3r@gmail.com>\n"
 "Language-Team: Илиян Илиев a.k.a Chep92 <bache_kiko18@abv.bg>\n"
@@ -2757,19 +2757,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/ca.po
+++ b/po/ca.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ca\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2016-07-14 02:00+0100\n"
 "Last-Translator: Eduard Ereza Martínez <eduard@eduardereza.com>\n"
 "Language-Team: \n"
@@ -2802,19 +2802,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/cs.po
+++ b/po/cs.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2012-10-10 22:10+0100\n"
 "Last-Translator: Adam Rambousek <rambousek@gmail.com>\n"
 "Language-Team:  <en@li.org>\n"
@@ -2823,19 +2823,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/da.po
+++ b/po/da.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: da\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Niels Martin Hansen <nielsm@indvikleren.dk>\n"
 "Language-Team: Niels Martin Hansen <nielsm@aegisub.org>\n"
@@ -3020,19 +3020,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2013-07-17 22:15+0100\n"
 "Last-Translator: Shimapan <erokawaii@yandex.ru>\n"
 "Language-Team: Pantsu ga daisuki <erokawaii@yandex.ru>\n"
@@ -2835,19 +2835,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/el.po
+++ b/po/el.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-05-23 16:08+0200\n"
 "Last-Translator: Arslanoglou Georgios <arslanoglou.georgios@gmail.com>\n"
 "Language-Team: Gpower2, Madarb <gpower2@yahoo.com, madarbwot@hotmail.com>\n"
@@ -2805,19 +2805,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/es.po
+++ b/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-09-14 19:11-0430\n"
 "Last-Translator: Tom Maneiro <tomman@tsdx.net.ve>\n"
 "Language-Team: TSDX Dubs LTDA. <tomman@tsdx.net.ve>\n"
@@ -2809,19 +2809,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.0.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-07-15 14:58+0100\n"
 "Last-Translator: Xabier Aramendi <azpidatziak@gmail.com>\n"
 "Language-Team: (EUS_Xabier Aramendi) <azpidatziak@gmail.com>\n"
@@ -2770,19 +2770,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/fa.po
+++ b/po/fa.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Meysam <meysam.ar@gmail.com>\n"
 "Language-Team: \n"
@@ -2995,19 +2995,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/fi.po
+++ b/po/fi.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-11-23 02:19+0200\n"
 "Last-Translator: Lasse Liehu <lasse.liehu@gmail.com>\n"
 "Language-Team: Finnish <lokalisointi@lists.coss.fi>\n"
@@ -2782,19 +2782,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Cirrus Wazza <cirrus_wazza@gmx.fr>\n"
 "Language-Team: Céréales Killer <cerkil@free.fr>\n"
@@ -2802,19 +2802,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2013-11-01 21:33+0100\n"
 "Last-Translator: Nuria Andión <nandiez@gmail.com>\n"
 "Language-Team: Proxecto Trasno <proxecto@trasno.net>\n"
@@ -2840,19 +2840,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/hu.po
+++ b/po/hu.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub Hungarian translation\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-11-08 13:56+0100\n"
 "Last-Translator: Yuri <yurielvtars@gmail.com>\n"
 "Language-Team: Yuri <yurielvtars@gmail.com>\n"
@@ -2749,19 +2749,19 @@ msgid "%i"
 msgstr "%i"
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-07-02 23:34+0700\n"
 "Last-Translator: doplank <doplank@gmx.com>\n"
 "Language-Team:  <doplank@gmx.com>\n"
@@ -2752,19 +2752,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/it.po
+++ b/po/it.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub Italian Translation\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: giafe <ocarinaoftime@live.it>\n"
@@ -2847,19 +2847,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aegisub\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Jan Ekstrom <jeebjp@gmail.com>\n"
 "Language-Team: G-MARK <http://g-mark.jpn.org/>\n"
@@ -3001,19 +3001,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/ko.po
+++ b/po/ko.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub-korea\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: FreeTime\n"
 "Language-Team: None\n"
@@ -2985,19 +2985,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/make_pot.sh
+++ b/po/make_pot.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+#Abort on error
+set -e
+
 maybe_append() {
   while read -r msg; do
     msgfile=$(echo $msg | cut -d'|' -f1)
@@ -7,13 +10,16 @@ maybe_append() {
     msgid=$(echo $msg | cut -d'|' -f3-)
 
     if ! grep -Fq "msgid $msgid" aegisub.pot; then
-      echo -e "\n#: $msgfile:$msgline\nmsgid $msgid\nmsgstr \"\"\n" >> aegisub.pot
+      printf "\n#: %s:%s\nmsgid %s\nmsgstr \"\"\n\n" \
+             "$msgfile" "$msgline" "$msgid" >> aegisub.pot
     fi
   done
 }
 
-find ../src -name \*.cpp -o -name \*.h | LC_ALL=C sort \
-  | xgettext --files-from=- -o - --c++ -k_ -kSTR_MENU -kSTR_DISP -kSTR_HELP -kfmt_tl -kfmt_plural:2,3 -kwxT -kwxPLURAL:1,2 \
+find ../src -name \*.cpp -o -name \*.h \
+  | LC_ALL=C sort \
+  | xgettext --files-from=- -o - --c++ \
+             -k_ -kSTR_MENU -kSTR_DISP -kSTR_HELP -kfmt_tl -kfmt_plural:2,3 -kwxT -kwxPLURAL:1,2 \
   | sed 's/SOME DESCRIPTIVE TITLE./Aegisub 3.3+/' \
   | sed 's/YEAR/2005-2020/' \
   | sed "s/THE PACKAGE'S COPYRIGHT HOLDER/Rodrigo Braz Monteiro, Niels Martin Hansen, Thomas Goyne et. al./" \
@@ -34,6 +40,7 @@ grep '"[A-Za-z ]\+" : {' -n ../src/libresrc/default_hotkey.json \
   | maybe_append
 
 find ../automation -name '*.lua' \
+  | LC_ALL=C sort \
   | xargs grep 'tr"[^"]*"' -o -n \
   | sed 's/\(.*\):\([0-9]\+\):tr\(".*"\)/\1|\2|\3/' \
   | sed 's/\\/\\\\\\\\/g' \

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2013-05-09 12:56+0100\n"
 "Last-Translator: Thomas De Rocker <thomasderocker@hotmail.com>\n"
 "Language-Team: Dutch (nl)\n"
@@ -2862,19 +2862,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/pl.po
+++ b/po/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2011-06-18 19:24+0100\n"
 "Last-Translator: Invi <adii__17@o2.pl>\n"
 "Language-Team: Invi <adii__17@o2.pl>\n"
@@ -2998,19 +2998,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2011-06-04 17:17-0300\n"
 "Last-Translator: Rodrigo Monteiro <amz@aegisub.net>\n"
 "Language-Team: Rodrigo Braz Monteiro\n"
@@ -3000,19 +3000,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-05-19 22:58-0000\n"
 "Last-Translator: Daniel Mota <1060446@isep.ipp.pt>\n"
 "Language-Team: Leinad4Mind <1060446@isep.ipp.pt> & RiCON <wiiaboo@gmail."
@@ -2789,19 +2789,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2012-10-04 22:11+0200\n"
 "Last-Translator: Igor Urazov <z0rc3r@gmail.com>\n"
 "Language-Team: \n"
@@ -2831,19 +2831,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/sr_RS.po
+++ b/po/sr_RS.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 2.1.9\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2012-09-23 06:00+0100\n"
 "Last-Translator: Rancher <theranchcowboy@gmail.com>\n"
 "Language-Team: Serbian\n"
@@ -2825,19 +2825,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/sr_RS@latin.po
+++ b/po/sr_RS@latin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 2.1.9\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2012-09-23 06:00+0100\n"
 "Last-Translator: Rancher <theranchcowboy@gmail.com>\n"
 "Language-Team: Serbian\n"
@@ -2825,19 +2825,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-09-18 19:57+0200\n"
 "Last-Translator: kotobenko <aniguysubs@gmail.com>\n"
 "Language-Team: LANGUAGE <aniguysubs@gmail.com>\n"
@@ -2748,19 +2748,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/vi.po
+++ b/po/vi.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub Tiếng Việt\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: NGUY?N M?nh Hùng <loveleeyoungae@yahoo.com>\n"
 "Language-Team: OnEsChi <oneschi@yahoo.com>\n"
@@ -2777,19 +2777,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2018-03-05 02:00+0800\n"
 "Last-Translator: ComputerFan <diannaomi97@gmail.com>\n"
 "Language-Team: Vmoe Fansub <vmoe@vmoe.info>\n"
@@ -2715,19 +2715,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Aegisub 3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-05 15:11-0400\n"
+"POT-Creation-Date: 2020-07-17 16:04+0200\n"
 "PO-Revision-Date: 2014-06-28 18:38+0800\n"
 "Last-Translator: COMPUTERFAN <diannaomi97@gmail.com>\n"
 "Language-Team: Vmoe字幕組 <diannaomi97@gmail.com>\n"
@@ -2717,19 +2717,19 @@ msgid "%i"
 msgstr ""
 
 #: ../src/dialog_align.cpp:108
-msgid "The key color to be followed."
+msgid "The key color to be followed"
 msgstr ""
 
 #: ../src/dialog_align.cpp:110
-msgid "The x coord of the key point."
+msgid "The x coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:112
-msgid "The y coord of the key point."
+msgid "The y coord of the key point"
 msgstr ""
 
 #: ../src/dialog_align.cpp:114
-msgid "Max tolerance of the color."
+msgid "Max tolerance of the color"
 msgstr ""
 
 #: ../src/dialog_align.cpp:121

--- a/src/dialog_align.cpp
+++ b/src/dialog_align.cpp
@@ -105,13 +105,13 @@ namespace {
 			selected_color->SetColor(agi::Color(r, g, b));
 			});
 		selected_color = new ColourButton(this, wxSize(55, 16), true, agi::Color("FFFFFF"));
-		selected_color->SetToolTip(_("The key color to be followed."));
+		selected_color->SetToolTip(_("The key color to be followed"));
 		selected_x = new wxTextCtrl(this, -1, "0");
-		selected_x->SetToolTip(_("The x coord of the key point."));
+		selected_x->SetToolTip(_("The x coord of the key point"));
 		selected_y = new wxTextCtrl(this, -1, "0");
-		selected_y->SetToolTip(_("The y coord of the key point."));
+		selected_y->SetToolTip(_("The y coord of the key point"));
 		selected_tolerance = new wxTextCtrl(this, -1, wxString::Format(wxT("%i"), int(tolerance)));
-		selected_tolerance->SetToolTip(_("Max tolerance of the color."));
+		selected_tolerance->SetToolTip(_("Max tolerance of the color"));
 
 		selected_x->Bind(wxEVT_TEXT, &DialogAlignToVideo::update_from_textbox, this);
 		selected_y->Bind(wxEVT_TEXT, &DialogAlignToVideo::update_from_textbox, this);

--- a/src/dialog_align.cpp
+++ b/src/dialog_align.cpp
@@ -156,12 +156,9 @@ namespace {
 
 	void rgb2lab(unsigned char r, unsigned char g, unsigned char b, double* lab)
 	{
-		double R = static_cast<double>(r) / 255.0;
-		double G = static_cast<double>(g) / 255.0;
-		double B = static_cast<double>(b) / 255.0;
-		double X = 0.412453 * R + 0.357580 * G + 0.180423 * B;
-		double Y = 0.212671 * R + 0.715160 * G + 0.072169 * B;
-		double Z = 0.019334 * R + 0.119193 * G + 0.950227 * B;
+		double X = (0.412453 * r + 0.357580 * g + 0.180423 * b) / 255.0;
+		double Y = (0.212671 * r + 0.715160 * g + 0.072169 * b) / 255.0;
+		double Z = (0.019334 * r + 0.119193 * g + 0.950227 * b) / 255.0;
 		double xr = X / 0.950456, yr = Y / 1.000, zr = Z / 1.088854;
 
 		if (yr > 0.008856) {


### PR DESCRIPTION
Afaik the AlignToVideo feature is specific to wangqr/Aegisub.

Using the “Align to video” feature with a tolerance of 0 would previously always result of the starttime being equal to the start time of the second next frame and similar with endtime, so `start<end` which doesn't make sense as every colour ought to be equal to itself.
This seemed simple enough, so I gave it a try. In addition a typo and a minor cosmetic nit are being fixed with this pr.

It also prevents arbitrary colours from being selected. I don't think it makes much sense to select a colour different from the one at the specified position – if not the logic of the main commit does not hold up as explained in the commit message.
I'm not really familiar with wxWidgets (or any GUI lib for that matter) so I'm not sure if my approach to disable arbitrary colour selection is sensible enough or if there's a better alternative to display colour without a button.

<br />

On an unrelated side note, I don't really understand what the goal of the pixel traversal in all four cardinal directions is. If a large body of similar colour is selected as a source this makes this feature very inperfomant (which is very noticeable for me). But maybe there's a good reason for it? Would a fixed position with a (configurable) position tolerance achieve the same? *(while limiting performance impact)*
*(Also this may lead to premature(?) abortion if the selected pixel still has the original value±tolerance, but the `l`,`r`,`d`,`u` positions move closer to the selected pixel.)* 

**EDIT:** force pushed because I initially forgot to also update the `aegisub.pot` file along with the `*.po` files.