### PR TITLE
po/de: Update German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,105 +7,106 @@ msgstr ""
 "Project-Id-Version: Aegisub 3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-07-17 13:16-0400\n"
-"PO-Revision-Date: 2013-07-17 22:15+0100\n"
-"Last-Translator: Shimapan <erokawaii@yandex.ru>\n"
+"PO-Revision-Date: 2020-07-26 17:57+0200\n"
+"Last-Translator: Oneric <oneric@nomail>\n"
 "Language-Team: Pantsu ga daisuki <erokawaii@yandex.ru>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.5.4\n"
+"Previous-Translator: Shimapan <erokawaii@yandex.ru>\n"
+"X-Generator: Poedit 2.2.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../automation/autoload/cleantags-autoload.lua:31
-#, fuzzy
 msgid "Clean Tags"
-msgstr "Tags verstecken"
+msgstr "Tags säubern"
 
 #: ../automation/autoload/cleantags-autoload.lua:32
 msgid ""
 "Clean subtitle lines by re-arranging ASS tags and override blocks within the "
 "lines"
-msgstr ""
+msgstr "Füge benachbarte Tag-Blöcke zusammen und sortiere die Tags darin"
 
 #: ../automation/autoload/kara-templater.lua:36
 #, fuzzy
 msgid "Karaoke Templater"
-msgstr "Karaoke-Vorlage"
+msgstr "Karaoke-Vorlagenumsetzer"
 
 #: ../automation/autoload/kara-templater.lua:37
 msgid ""
 "Macro and export filter to apply karaoke effects using the template language"
-msgstr ""
+msgstr "Makro und Export-Filter, der Karaoke-Vorlagen anwendet"
 
 #: ../automation/autoload/kara-templater.lua:860
 msgid "Applies karaoke effects from templates"
-msgstr ""
+msgstr "Wendet Karaoke-Vorlagen an"
 
 #: ../automation/autoload/kara-templater.lua:860
-#, fuzzy
 msgid "Apply karaoke template"
-msgstr "Karaoke-Vorlage"
+msgstr "Karaoke-Vorlage anwenden"
 
 #: ../automation/autoload/kara-templater.lua:861
 msgid ""
 "Apply karaoke effect templates to the subtitles.\\n\\nSee the help file for "
 "information on how to use this."
 msgstr ""
+"Wendet Karaoke-Vorlage an.\n"
+"\n"
+"Siehe Hilfedatei für nähere Infos zur Verwendung."
 
 #: ../automation/autoload/kara-templater.lua:861
-#, fuzzy
 msgid "Karaoke template"
 msgstr "Karaoke-Vorlage"
 
 #: ../automation/autoload/karaoke-auto-leadin.lua:32
-#, fuzzy
 msgid "Automatic karaoke lead-in"
-msgstr "Automatisch speichern"
+msgstr "Automatischer Karaoke-Einlaufbereich"
 
 #: ../automation/autoload/karaoke-auto-leadin.lua:33
-#, fuzzy
 msgid "Join up the ends of selected lines and add \\\\k tags to shift karaoke"
-msgstr "Fügt die markierten Zeilen zu einer zusammen (als Karaoke)"
+msgstr ""
+"Lücken zwischen gewählten Zeilen durch Einlaufber. füllen; füge \\k-Tags "
+"hinzu um Karaoke-Timing zu erhalten"
 
 #: ../automation/autoload/macro-1-edgeblur.lua:6
 msgid "Add edgeblur"
-msgstr ""
+msgstr "Füge \\be-Tags hinzu"
 
 #: ../automation/autoload/macro-1-edgeblur.lua:7
 msgid "A demo macro showing how to do simple line modification in Automation 4"
 msgstr ""
+"Makro zur Veranschaulichung einfacher Zeilenmodifikation in Automation 4"
 
 #: ../automation/autoload/macro-1-edgeblur.lua:21
-#, fuzzy
 msgid "Adds \\\\be1 tags to all selected lines"
-msgstr "Vertauscht die ausgewählten Zeilen miteinander"
+msgstr "Fügt allen ausgewählten Zeilen \\be1-Tags hinzu"
 
 #: ../automation/autoload/macro-2-mkfullwitdh.lua:77
 #, fuzzy
 msgid "Make fullwidth"
-msgstr "Standardbreite"
+msgstr "Zu Vollbreite konvertieren"
 
 #: ../automation/autoload/macro-2-mkfullwitdh.lua:80
 msgid "Convert Latin letters to SJIS fullwidth letters"
-msgstr ""
+msgstr "Ersetze lateinische Buchstaben durch ihre SJIS-Vollbreitenform"
 
 #: ../automation/autoload/strip-tags.lua:17
 msgid "Strip tags"
-msgstr ""
+msgstr "Entferne Tags"
 
 #: ../automation/autoload/strip-tags.lua:18
 msgid "Remove all override tags from selected lines"
-msgstr ""
+msgstr "Entfernte alle Tags der ausgewählten Zeilen"
 
 #: ../automation/autoload/strip-tags.lua:28
 msgid "strip tags"
-msgstr ""
+msgstr "entferne Tags"
 
 #: ../packages/desktop/aegisub.desktop.template.in:5
-#, fuzzy
 msgid "Aegisub"
-msgstr "Über Aegisub"
+msgstr "Aegisub"
 
 #: ../packages/desktop/aegisub.desktop.template.in:6
 msgid "Subtitle Editor"
@@ -115,13 +116,15 @@ msgstr "Untertitel-Editor"
 msgid "Create and edit subtitles for film and videos."
 msgstr "Erzeugt und bearbeitet Untertitel für Filme und Videos."
 
+# Translators: Search terms to find this application. Do NOT translate or
+# localize the semicolons! The list MUST also end with a semicolon!
 #: ../packages/desktop/aegisub.desktop.template.in:13
 msgid "subtitles;subtitle;captions;captioning;video;audio;"
-msgstr ""
+msgstr "Untertitel;ASS;Video;Audio;"
 
 #: ../src/ass_style.cpp:195
 msgid "ANSI"
-msgstr "Ansi"
+msgstr "ANSI"
 
 #: ../src/ass_style.cpp:196 ../src/command/video.cpp:146
 msgid "Default"
@@ -137,7 +140,7 @@ msgstr "Mac"
 
 #: ../src/ass_style.cpp:199
 msgid "Shift_JIS"
-msgstr "Shift-Jis"
+msgstr "Shift-JIS"
 
 #: ../src/ass_style.cpp:200
 msgid "Hangeul"
@@ -193,15 +196,15 @@ msgstr "Osteuropäisch"
 
 #: ../src/ass_style.cpp:213
 msgid "OEM"
-msgstr "Oem"
+msgstr "OEM"
 
 #: ../src/audio_box.cpp:73
 msgid "Horizontal zoom"
-msgstr "Horizontale Vergrößerung"
+msgstr "Horizontaler Zoom"
 
 #: ../src/audio_box.cpp:74
 msgid "Vertical zoom"
-msgstr "Vertikale Vergrößerung"
+msgstr "Vertikaler Zoom"
 
 #: ../src/audio_box.cpp:75
 msgid "Audio Volume"
@@ -258,11 +261,13 @@ msgid "karaoke timing"
 msgstr "Karaoke-Timing"
 
 #: ../src/auto4_base.cpp:457
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Failed to load Automation script '%s':\n"
 "%s"
-msgstr "Automatisch geladende Automatisierungs-Skripte neu geladen"
+msgstr ""
+"Konnte Automatisierungsskript '%s' nicht laden:\n"
+"%s"
 
 #: ../src/auto4_base.cpp:464
 #, c-format
@@ -299,11 +304,11 @@ msgstr "Zeichensatz auswählen"
 
 #: ../src/command/app.cpp:57
 msgid "&About"
-msgstr "&Über..."
+msgstr "&Über"
 
 #: ../src/command/app.cpp:58
 msgid "About"
-msgstr "Über..."
+msgstr "Über"
 
 #: ../src/command/app.cpp:59 ../src/dialog_about.cpp:44
 msgid "About Aegisub"
@@ -311,55 +316,51 @@ msgstr "Über Aegisub"
 
 #: ../src/command/app.cpp:68
 msgid "&Audio+Subs View"
-msgstr "Audio+Untertitel anzeigen"
+msgstr "&Audio+Untertitel Ansicht"
 
 #: ../src/command/app.cpp:69
 msgid "Audio+Subs View"
-msgstr "Audio+Untertitel anzeigen"
+msgstr "Audio+Untertitel Ansicht"
 
 #: ../src/command/app.cpp:70
-#, fuzzy
 msgid "Display audio and the subtitles grid only"
-msgstr "Zeigt Untertitel und Audiofenster an"
+msgstr "Nur Audio und Untertitelgitter anzeigen"
 
 #: ../src/command/app.cpp:88
 msgid "&Full view"
-msgstr "Volle Ansicht"
+msgstr "V&olle Ansicht"
 
 #: ../src/command/app.cpp:89
 msgid "Full view"
 msgstr "Volle Ansicht"
 
 #: ../src/command/app.cpp:90
-#, fuzzy
 msgid "Display audio, video and then subtitles grid"
-msgstr "Zeigt Audio, Video und Untertitel an"
+msgstr "Sowohl Audio, Video als auch Untertitelgitter anzeigen"
 
 #: ../src/command/app.cpp:108
 msgid "S&ubs Only View"
-msgstr "Nur Untertitel anzeigen"
+msgstr "N&ur Untertitel anzeigen"
 
 #: ../src/command/app.cpp:109
 msgid "Subs Only View"
 msgstr "Nur Untertitel anzeigen"
 
 #: ../src/command/app.cpp:110
-#, fuzzy
 msgid "Display the subtitles grid only"
-msgstr "Zeigt nur die Untertitel an"
+msgstr "Nur das Untertitelgitter anzeigen"
 
 #: ../src/command/app.cpp:124
 msgid "&Video+Subs View"
-msgstr "Video+Untertitel anzeigen"
+msgstr "&Video+Untertitel Ansicht"
 
 #: ../src/command/app.cpp:125
 msgid "Video+Subs View"
-msgstr "Video+Untertitel"
+msgstr "Video+Untertitel Ansicht"
 
 #: ../src/command/app.cpp:126
-#, fuzzy
 msgid "Display video and the subtitles grid only"
-msgstr "Zeigt nur Untertitel und Videofenster an"
+msgstr "Nur Video und Untertitelgitter anzeigen"
 
 #: ../src/command/app.cpp:144
 msgid "E&xit"
@@ -411,7 +412,7 @@ msgstr "Öffne ein neues Programmfenster"
 
 #: ../src/command/app.cpp:205
 msgid "&Options..."
-msgstr "Einstellungen"
+msgstr "Einstellungen..."
 
 #: ../src/command/app.cpp:206 ../src/dialog_properties.cpp:146
 #: ../src/dialog_timing_processor.cpp:168 ../src/preferences.cpp:130
@@ -428,9 +429,8 @@ msgid "Toggle global hotkey overrides"
 msgstr "Globale Hotkeys umschalten"
 
 #: ../src/command/app.cpp:223
-#, fuzzy
 msgid "Toggle global hotkey overrides (Medusa Mode)"
-msgstr "Globale Hotkeys umschalten"
+msgstr "Globale Hotkeys umschalten (Medusa Modus)"
 
 #: ../src/command/app.cpp:238
 msgid "Toggle the main toolbar"
@@ -458,28 +458,29 @@ msgstr "Überprüfen, ob eine neue Version von Aegisub verfügbar ist"
 
 #: ../src/command/app.cpp:271 ../src/command/app.cpp:272
 msgid "Minimize"
-msgstr ""
+msgstr "Minimieren"
 
 #: ../src/command/app.cpp:273
 msgid "Minimize the active window"
-msgstr ""
+msgstr "Minimiere das aktive Fenster"
 
+# Apple-spezifisches Kommando zum Fenster maximieren.
 #: ../src/command/app.cpp:282 ../src/command/app.cpp:283
 #, fuzzy
 msgid "Zoom"
-msgstr "Hereinzoomen"
+msgstr "Zoom"
 
 #: ../src/command/app.cpp:284
 msgid "Maximize the active window"
-msgstr ""
+msgstr "Maximiere das aktive Fenster"
 
 #: ../src/command/app.cpp:293 ../src/command/app.cpp:294
 msgid "Bring All to Front"
-msgstr ""
+msgstr "In Vordergrund bringen"
 
 #: ../src/command/app.cpp:295
 msgid "Bring forward all open documents to the front"
-msgstr ""
+msgstr "Bringe alle offenen Fenster in den Vordergrund"
 
 #: ../src/command/audio.cpp:66
 msgid "&Close Audio"
@@ -490,7 +491,6 @@ msgid "Close Audio"
 msgstr "Audio schließen"
 
 #: ../src/command/audio.cpp:68
-#, fuzzy
 msgid "Close the currently open audio file"
 msgstr "Schließt die geöffnete Audiodatei"
 
@@ -500,12 +500,11 @@ msgstr "Ö&ffne Audiodatei..."
 
 #: ../src/command/audio.cpp:79 ../src/command/audio.cpp:86
 msgid "Open Audio File"
-msgstr "Öffne Audiodatei..."
+msgstr "Öffne Audiodatei"
 
 #: ../src/command/audio.cpp:80
-#, fuzzy
 msgid "Open an audio file"
-msgstr "Öffnet eine Audiodatei"
+msgstr "Öffne eine Audiodatei"
 
 #: ../src/command/audio.cpp:83
 msgid "Audio Formats"
@@ -542,9 +541,8 @@ msgid "Open Audio from Video"
 msgstr "Öffne Tonspur von &Video"
 
 #: ../src/command/audio.cpp:119
-#, fuzzy
 msgid "Open the audio from the current video file"
-msgstr "Öffnet eine Tonspur der aktuellen Videodatei"
+msgstr "Öffnet die Tonspur der aktuellen Videodatei"
 
 #: ../src/command/audio.cpp:133
 msgid "&Spectrum Display"
@@ -568,16 +566,15 @@ msgstr "Wellenform anzeigen"
 
 #: ../src/command/audio.cpp:151
 msgid "Display audio as a linear amplitude graph"
-msgstr "Zeige Audio als linearen Amplitudengrafen an"
+msgstr "Zeige Audio als linearen Amplitudengraphen an"
 
 #: ../src/command/audio.cpp:165 ../src/command/audio.cpp:166
 msgid "Create audio clip"
 msgstr "Erzeuge einen Audioclip"
 
 #: ../src/command/audio.cpp:167
-#, fuzzy
 msgid "Save an audio clip of the selected line"
-msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+msgstr "Exportiere Audioclip für die ausgewählten Zeilen"
 
 #: ../src/command/audio.cpp:178
 msgid "Save audio clip"
@@ -598,9 +595,8 @@ msgid "Play current line"
 msgstr "Aktuelle Zeile abspielen"
 
 #: ../src/command/audio.cpp:208
-#, fuzzy
 msgid "Play the audio for the current line"
-msgstr "Öffnet eine Tonspur der aktuellen Videodatei"
+msgstr "Spiele Ton der ausgewählten Zeile ab"
 
 #: ../src/command/audio.cpp:221 ../src/command/audio.cpp:222
 msgid "Play audio selection"
@@ -615,7 +611,6 @@ msgid "Play audio selection or stop"
 msgstr "Audio-Auswahl wiedergeben oder anhalten"
 
 #: ../src/command/audio.cpp:235
-#, fuzzy
 msgid "Play selection, or stop playback if it's already playing"
 msgstr "Auswahl wiedergeben oder bei Wiedergabe anhalten"
 
@@ -624,9 +619,8 @@ msgid "Stop playing"
 msgstr "Wiedergabe anhalten"
 
 #: ../src/command/audio.cpp:252
-#, fuzzy
 msgid "Stop audio and video playback"
-msgstr "Stoppe Abspielen"
+msgstr "Audio- und Videowiedergabe abbrechen"
 
 #: ../src/command/audio.cpp:268 ../src/command/audio.cpp:269
 #: ../src/command/audio.cpp:270
@@ -696,7 +690,7 @@ msgstr "Gehe zur Auswahl"
 
 #: ../src/command/audio.cpp:400
 msgid "Scroll the audio display to center on the current audio selection"
-msgstr ""
+msgstr "Zentriere Audio-Anzeige auf aktuelle Auswahl"
 
 #: ../src/command/audio.cpp:409 ../src/command/audio.cpp:410
 msgid "Scroll left"
@@ -716,9 +710,8 @@ msgstr "Audioanzeige nach rechts scrollen"
 
 #: ../src/command/audio.cpp:436 ../src/command/audio.cpp:437
 #: ../src/command/audio.cpp:438
-#, fuzzy
 msgid "Auto scroll audio display to selected line"
-msgstr "Audioanzeige automatisch auf ausgewählte Zeile setzen"
+msgstr "Audioanzeige automatisch zu gewählter Zeile verschieben"
 
 #: ../src/command/audio.cpp:453 ../src/command/audio.cpp:454
 #: ../src/command/audio.cpp:455
@@ -726,14 +719,12 @@ msgid "Automatically commit all changes"
 msgstr "Änderungen automatisch anwenden"
 
 #: ../src/command/audio.cpp:470 ../src/command/audio.cpp:471
-#, fuzzy
 msgid "Auto go to next line on commit"
-msgstr "Automatisch nach dem Anwenden zur nächsten Zeile gehen"
+msgstr "Nach dem Anwenden direkt zur nächsten Zeile wechseln"
 
 #: ../src/command/audio.cpp:472
-#, fuzzy
 msgid "Automatically go to next line on commit"
-msgstr "Automatisch nach dem Anwenden zur nächsten Zeile gehen"
+msgstr "Nach dem Anwenden, automatisch zur nächsten Zeile wechseln"
 
 #: ../src/command/audio.cpp:487 ../src/command/audio.cpp:488
 #: ../src/command/audio.cpp:489
@@ -770,11 +761,11 @@ msgstr "Alle Automatisierungs-Skripte neu geladen"
 
 #: ../src/command/automation.cpp:61
 msgid "R&eload autoload Automation scripts"
-msgstr "Lade automatisch geladende Automatisierungs-Skripte neu"
+msgstr "Lade automatisch geladene Automatisierungs-Skripte neu"
 
 #: ../src/command/automation.cpp:62
 msgid "Reload autoload Automation scripts"
-msgstr "Lade automatisch geladende Automatisierungs-Skripte neu"
+msgstr "Lade automatisch geladene Automatisierungs-Skripte neu"
 
 #: ../src/command/automation.cpp:63
 msgid "Rescan the Automation autoload folder"
@@ -782,7 +773,7 @@ msgstr "Autom.-Laden-Ordner neu prüfen"
 
 #: ../src/command/automation.cpp:67
 msgid "Reloaded autoload Automation scripts"
-msgstr "Automatisch geladende Automatisierungs-Skripte neu geladen"
+msgstr "Automatisch geladene Automatisierungs-Skripte neu geladen"
 
 #: ../src/command/automation.cpp:74 ../src/command/automation.cpp:86
 msgid "&Automation..."
@@ -802,6 +793,9 @@ msgid ""
 "Open automation manager. Ctrl: Rescan autoload folder. Ctrl+Shift: Rescan "
 "autoload folder and reload all automation scripts"
 msgstr ""
+"Automatisierungs-Manager öffnen\n"
+"Strg: Autom.-Laden neu prüfen\n"
+"Strg+Shift: Zusätzlich alle Skripte neu laden"
 
 #: ../src/command/command.cpp:31
 #, c-format
@@ -921,7 +915,7 @@ msgstr "Durchgestrichen ein/aus"
 
 #: ../src/command/edit.cpp:484
 msgid "Font Face..."
-msgstr "Schriftart"
+msgstr "Schriftart..."
 
 #: ../src/command/edit.cpp:485 ../src/preferences_base.cpp:251
 msgid "Font Face"
@@ -929,7 +923,7 @@ msgstr "Schriftart"
 
 #: ../src/command/edit.cpp:486
 msgid "Select a font face and size"
-msgstr "Schriftart und Größe auswählen"
+msgstr "Schriftart und -größe auswählen"
 
 #: ../src/command/edit.cpp:513
 msgid "set font"
@@ -956,9 +950,8 @@ msgid "Copy Lines"
 msgstr "Kopiere Zeilen"
 
 #: ../src/command/edit.cpp:605
-#, fuzzy
 msgid "Copy subtitles to the clipboard"
-msgstr "Bild in die Zwischenablage kopieren"
+msgstr "Kopiere Untertitel in die Zwischenablage"
 
 #: ../src/command/edit.cpp:626
 msgid "Cu&t Lines"
@@ -1013,26 +1006,28 @@ msgid "Duplicate the selected lines"
 msgstr "Markierte Zeilen duplizieren"
 
 #: ../src/command/edit.cpp:731 ../src/command/edit.cpp:732
-#, fuzzy
 msgid "Split lines after current frame"
-msgstr "Zeile nach der aktuellen einfügen"
+msgstr "Teile Zeile nach dem aktuellen Frame"
 
 #: ../src/command/edit.cpp:733
 msgid ""
 "Split the current line into a line which ends on the current frame and a "
 "line which starts on the next frame"
 msgstr ""
+"Teile die aktuelle Zeile in zwei auf. Eine wird bis zum aktuellen Frame "
+"gehen, die andere erst im nächsten Frame beginnen"
 
 #: ../src/command/edit.cpp:743 ../src/command/edit.cpp:744
-#, fuzzy
 msgid "Split lines before current frame"
-msgstr "Zeile vor aktueller einfügen"
+msgstr "Teile Zeile vor aktuellem Frame"
 
 #: ../src/command/edit.cpp:745
 msgid ""
 "Split the current line into a line which ends on the previous frame and a "
 "line which starts on the current frame"
 msgstr ""
+"Teile die aktuelle Zeile in zwei auf. Eine wird im vorigem Frame enden, die "
+"andere im aktuellen Frame beginnen"
 
 #: ../src/command/edit.cpp:785
 msgid "As &Karaoke"
@@ -1043,9 +1038,8 @@ msgid "As Karaoke"
 msgstr "Als Karaoke"
 
 #: ../src/command/edit.cpp:787
-#, fuzzy
 msgid "Join selected lines in a single one, as karaoke"
-msgstr "Fügt die markierten Zeilen zu einer zusammen (als Karaoke)"
+msgstr "Kombiniert gewählte Zeilen zu einer einzigen (als Karaoke)"
 
 #: ../src/command/edit.cpp:790
 msgid "join as karaoke"
@@ -1060,11 +1054,8 @@ msgid "Concatenate"
 msgstr "&Zusammenfügen (verbinden)"
 
 #: ../src/command/edit.cpp:798
-#, fuzzy
 msgid "Join selected lines in a single one, concatenating text together"
-msgstr ""
-"Fügt die ausgewählten Zeilen zu einer einzigen zusammen, der Text wird "
-"aneinandergehängt"
+msgstr "Kombiniert gewählte Zeilen zu einer, Text wird aneinandergehängt"
 
 #: ../src/command/edit.cpp:801 ../src/command/edit.cpp:812
 msgid "join lines"
@@ -1079,13 +1070,12 @@ msgid "Keep First"
 msgstr "Erhalte erste"
 
 #: ../src/command/edit.cpp:809
-#, fuzzy
 msgid ""
 "Join selected lines in a single one, keeping text of first and discarding "
 "remaining"
 msgstr ""
-"Fügt die ausgewählten Zeilen zu einer, erhält den ersten Text und verwirft "
-"den restlichen"
+"Kombiniert gewählte Zeilen zu einer, erhält den ersten Text und verwirft den "
+"Rest"
 
 #: ../src/command/edit.cpp:850
 msgid "&Paste Lines"
@@ -1105,7 +1095,7 @@ msgstr "Zeilen überschreiben..."
 
 #: ../src/command/edit.cpp:882
 msgid "Paste Lines Over"
-msgstr "Zeilen überschreiben..."
+msgstr "Zeilen überschreiben"
 
 #: ../src/command/edit.cpp:883
 msgid "Paste subtitles over others"
@@ -1120,9 +1110,8 @@ msgid "Recombine Lines"
 msgstr "Zeilen kombinieren"
 
 #: ../src/command/edit.cpp:968
-#, fuzzy
 msgid "Recombine subtitles which have been split and merged"
-msgstr "Untertitel kombinieren, wenn sie aufgeteilt und zusammengeführt wurden"
+msgstr "Untertitel rekombinieren, falls sie zuvor geteilt und vereinigt wurden"
 
 #: ../src/command/edit.cpp:1038
 msgid "combining"
@@ -1133,9 +1122,8 @@ msgid "Split Lines (by karaoke)"
 msgstr "Auftrennen (entlang Karaoke)"
 
 #: ../src/command/edit.cpp:1046
-#, fuzzy
 msgid "Use karaoke timing to split line into multiple smaller lines"
-msgstr "Nutzt Karaoketiming, um die Zeilen in viele kürzere Zeilen zu splitten"
+msgstr "Zeilen anhand des Karaoke-Timing in viele kürzere Zeilen zerhacken"
 
 #: ../src/command/edit.cpp:1080
 msgid "splitting"
@@ -1144,15 +1132,15 @@ msgstr "Splitten"
 #: ../src/command/edit.cpp:1112 ../src/command/edit.cpp:1113
 #: ../src/subs_edit_ctrl.cpp:416
 msgid "Split at cursor (estimate times)"
-msgstr "Bei Cursor auftrennen (Zeiten annähern)"
+msgstr "Bei Cursor auftrennen (Zeiten vermuten)"
 
 #: ../src/command/edit.cpp:1114
 msgid ""
 "Split the current line at the cursor, dividing the original line's duration "
 "between the new ones"
 msgstr ""
-"Aktuelle Zeile am Cursor aufteilen und die ursprüngliche Zeitdauer zwischen "
-"den neuen Zeilen auteilen"
+"Aktuelle Zeile am Textcursor zerteilen; Zeitdauer wird nach Textmenge "
+"aufgeteilt"
 
 #: ../src/command/edit.cpp:1128 ../src/command/edit.cpp:1129
 #: ../src/subs_edit_ctrl.cpp:415
@@ -1164,27 +1152,24 @@ msgid ""
 "Split the current line at the cursor, setting both lines to the original "
 "line's times"
 msgstr ""
-"Aktuelle Zeile am Cursor aufteilen und beide Zeilen auf die ursprüngliche "
-"Zeitdauer setzen"
+"Aktuelle Zeile am Textcursor zerteilen; beide Zeilen behalten die Start- und "
+"Endzeit"
 
 #: ../src/command/edit.cpp:1139 ../src/command/edit.cpp:1140
-#, fuzzy
 msgid "Split at cursor (at video frame)"
-msgstr "Bei Cursor auftrennen (Zeiten annähern)"
+msgstr "Bei Cursor auftrennen (Videoframe)"
 
 #: ../src/command/edit.cpp:1141
-#, fuzzy
 msgid ""
 "Split the current line at the cursor, dividing the line's duration at the "
 "current video frame"
 msgstr ""
-"Aktuelle Zeile am Cursor aufteilen und die ursprüngliche Zeitdauer zwischen "
-"den neuen Zeilen auteilen"
+"Aktuelle Zeile am Textcursor zerteilen; Zeitdauer wird am momentanen "
+"Videoframe zerteilt"
 
 #: ../src/command/edit.cpp:1157
-#, fuzzy
 msgid "Redo last undone action"
-msgstr "Wiederholt die letzte rückgängig gemachte Aktion"
+msgstr "Stellt die letzte rückgängig gemachte Aktion wiederher"
 
 #: ../src/command/edit.cpp:1162
 msgid "Nothing to &redo"
@@ -1205,7 +1190,6 @@ msgid "Redo %s"
 msgstr "Wiederholen %s"
 
 #: ../src/command/edit.cpp:1183
-#, fuzzy
 msgid "Undo last action"
 msgstr "Macht die letzte Aktion rückgängig"
 
@@ -1427,15 +1411,15 @@ msgstr "Durchlaufe Modi der Tag-Anzeige"
 
 #: ../src/command/grid.cpp:266
 msgid "ASS Override Tag mode set to show full tags."
-msgstr "ass-Tag-Modus auf 'alle Tags' setzen."
+msgstr "ASS-Tag-Modus auf 'alle Tags' setzen."
 
 #: ../src/command/grid.cpp:267
 msgid "ASS Override Tag mode set to simplify tags."
-msgstr "ass-Tag-Modus auf 'einfache Tags' setzen."
+msgstr "ASS-Tag-Modus auf 'einfache Tags' setzen."
 
 #: ../src/command/grid.cpp:268
 msgid "ASS Override Tag mode set to hide tags."
-msgstr "ass-Tag-Modus auf 'Tags verstecken' setzen."
+msgstr "ASS-Tag-Modus auf 'Tags verstecken' setzen."
 
 #: ../src/command/grid.cpp:278
 msgid "&Hide Tags"
@@ -1499,9 +1483,8 @@ msgid "Swap Lines"
 msgstr "Zeilen vertauschen"
 
 #: ../src/command/grid.cpp:385
-#, fuzzy
 msgid "Swap the two selected lines"
-msgstr "Vertauscht die ausgewählten Zeilen miteinander"
+msgstr "Vertauscht die zwei ausgewählten Zeilen"
 
 #: ../src/command/grid.cpp:396
 msgid "swap lines"
@@ -1535,15 +1518,15 @@ msgstr "Hilfethemen"
 
 #: ../src/command/help.cpp:81
 msgid "&IRC Channel"
-msgstr "&Irc-Kanal"
+msgstr "&IRC-Kanal"
 
 #: ../src/command/help.cpp:82
 msgid "IRC Channel"
-msgstr "Irc-Kanal"
+msgstr "IRC-Kanal"
 
 #: ../src/command/help.cpp:83
 msgid "Visit Aegisub's official IRC channel"
-msgstr "Aegisubs offiziellen Irc-Channel öffnen"
+msgstr "Aegisubs offiziellen IRC-Channel öffnen"
 
 #: ../src/command/help.cpp:93
 msgid "&Visual Typesetting"
@@ -1574,11 +1557,10 @@ msgid "Close Keyframes"
 msgstr "Schließe Keyframe-Datei"
 
 #: ../src/command/keyframe.cpp:52
-#, fuzzy
 msgid ""
 "Discard the currently loaded keyframes and use those from the video, if any"
 msgstr ""
-"Speichere den gerade angezeigten Frame als .png-Bild im Ordner des Videos"
+"Verwerfe momentane Keyframes; falls vorhanden, lade Keyframes des Videos"
 
 #: ../src/command/keyframe.cpp:67
 msgid "Open Keyframes..."
@@ -1586,12 +1568,11 @@ msgstr "Öffne Keyframe-Datei..."
 
 #: ../src/command/keyframe.cpp:68
 msgid "Open Keyframes"
-msgstr "Öffne Keyframe-Datei..."
+msgstr "Öffne Keyframe-Datei"
 
 #: ../src/command/keyframe.cpp:69
-#, fuzzy
 msgid "Open a keyframe list file"
-msgstr "Öffnet eine Keyframe-Datei"
+msgstr "Öffne eine Keyframe-Datei"
 
 #: ../src/command/keyframe.cpp:73
 msgid "Open keyframes file"
@@ -1603,12 +1584,11 @@ msgstr "Speichere Keyframe-Datei..."
 
 #: ../src/command/keyframe.cpp:89
 msgid "Save Keyframes"
-msgstr "Speichere Keyframe-Datei..."
+msgstr "Speichere Keyframe-Datei"
 
 #: ../src/command/keyframe.cpp:90
-#, fuzzy
 msgid "Save the current list of keyframes to a file"
-msgstr "Speichert die aktuelle Keyframeliste"
+msgstr "Speichere die aktuelle Keyframeliste"
 
 #: ../src/command/keyframe.cpp:98
 msgid "Save keyframes file"
@@ -1658,9 +1638,8 @@ msgid "Attachments"
 msgstr "Anhänge"
 
 #: ../src/command/subtitle.cpp:82
-#, fuzzy
 msgid "Open the attachment manager dialog"
-msgstr "Öffnet die Liste der Anhänge"
+msgstr "Öffnet den Anhangsverwalter"
 
 #: ../src/command/subtitle.cpp:93
 msgid "&Find..."
@@ -1671,9 +1650,8 @@ msgid "Find"
 msgstr "Suchen"
 
 #: ../src/command/subtitle.cpp:95
-#, fuzzy
 msgid "Search for text in the subtitles"
-msgstr "Zeige alle Tags im Untertitelgitter"
+msgstr "Durchsuche Untertitel nach Text"
 
 #: ../src/command/subtitle.cpp:106
 msgid "Find &Next"
@@ -1684,7 +1662,6 @@ msgid "Find Next"
 msgstr "Nächstes Vorkommen"
 
 #: ../src/command/subtitle.cpp:108
-#, fuzzy
 msgid "Find next match of last search"
 msgstr "Suche nächstes Vorkommen der letzten Suchanfrage"
 
@@ -1697,16 +1674,14 @@ msgid "After Current"
 msgstr "Nach aktueller"
 
 #: ../src/command/subtitle.cpp:137
-#, fuzzy
 msgid "Insert a new line after the current one"
-msgstr "Zeile nach der aktuellen einfügen"
+msgstr "Neue Zeile nach aktueller einfügen"
 
 #: ../src/command/subtitle.cpp:169 ../src/command/subtitle.cpp:170
 msgid "After Current, at Video Time"
 msgstr "Nach aktueller, bei Videozeit"
 
 #: ../src/command/subtitle.cpp:171
-#, fuzzy
 msgid "Insert a new line after the current one, starting at video time"
 msgstr "Fügt eine Zeile nach der aktuellen ein (ab aktueller Videozeit)"
 
@@ -1719,16 +1694,14 @@ msgid "Before Current"
 msgstr "Vor aktueller"
 
 #: ../src/command/subtitle.cpp:182
-#, fuzzy
 msgid "Insert a new line before the current one"
-msgstr "Zeile vor aktueller einfügen"
+msgstr "Neue Zeile vor aktueller einfügen"
 
 #: ../src/command/subtitle.cpp:211 ../src/command/subtitle.cpp:212
 msgid "Before Current, at Video Time"
 msgstr "Vor aktueller, bei Videozeit"
 
 #: ../src/command/subtitle.cpp:213
-#, fuzzy
 msgid "Insert a new line before the current one, starting at video time"
 msgstr "Fügt eine Zeile vor der aktuellen ein (ab aktueller Videozeit)"
 
@@ -1759,9 +1732,8 @@ msgid "Open Subtitles"
 msgstr "Öffne Untertitel"
 
 #: ../src/command/subtitle.cpp:270
-#, fuzzy
 msgid "Open a subtitles file"
-msgstr "Öffnet eine Untertitel-Datei"
+msgstr "Öffne eine Untertitel-Datei"
 
 #: ../src/command/subtitle.cpp:275 ../src/command/subtitle.cpp:305
 #: ../src/dialog_style_manager.cpp:677
@@ -1780,20 +1752,19 @@ msgstr "Öffne Autosave-Untertitel"
 msgid "Open a previous version of a file which was autosaved by Aegisub"
 msgstr ""
 "Öffne eine vorherige Version einer Datei, die von Aegisub automatisch "
-"gespeichert wurde."
+"gespeichert wurde"
 
 #: ../src/command/subtitle.cpp:298
 msgid "Open Subtitles with &Charset..."
-msgstr "Öffne Untertitel mit &Zeichensatz"
+msgstr "Öffne Untertitel mit &Zeichensatz..."
 
 #: ../src/command/subtitle.cpp:299
 msgid "Open Subtitles with Charset"
 msgstr "Öffne Untertitel mit &Zeichensatz"
 
 #: ../src/command/subtitle.cpp:300
-#, fuzzy
 msgid "Open a subtitles file with a specific file encoding"
-msgstr "Öffnet eine Untertitel-Datei mit einem bestimmten Zeichensatz"
+msgstr "Öffne Untertitel-Datei mit einem bestimmten Zeichensatz"
 
 #: ../src/command/subtitle.cpp:308
 msgid "Charset"
@@ -1812,9 +1783,8 @@ msgid "Open Subtitles from Video"
 msgstr "Öffne Untertitel vom Video"
 
 #: ../src/command/subtitle.cpp:319
-#, fuzzy
 msgid "Open the subtitles from the current video file"
-msgstr "Öffnet die Untertitel der aktuellen Videodatei"
+msgstr "Öffne die Untertitel der aktuellen Videodatei"
 
 #: ../src/command/subtitle.cpp:335
 msgid "&Properties..."
@@ -1841,9 +1811,8 @@ msgid "Save Subtitles"
 msgstr "&Speichere Untertitel"
 
 #: ../src/command/subtitle.cpp:370
-#, fuzzy
 msgid "Save the current subtitles"
-msgstr "Letzte Untertitel öffnen"
+msgstr "Speichere die momentanen Untertitel"
 
 #: ../src/command/subtitle.cpp:385
 msgid "Save Subtitles &as..."
@@ -1851,10 +1820,9 @@ msgstr "Speichere Untertitel unter..."
 
 #: ../src/command/subtitle.cpp:386
 msgid "Save Subtitles as"
-msgstr "Speichere Untertitel unter..."
+msgstr "Speichere Untertitel unter"
 
 #: ../src/command/subtitle.cpp:387
-#, fuzzy
 msgid "Save subtitles with another name"
 msgstr "Speichert die Untertitel-Datei unter anderem Namen"
 
@@ -1868,18 +1836,16 @@ msgid "Select All"
 msgstr "Alles aus&wählen"
 
 #: ../src/command/subtitle.cpp:398
-#, fuzzy
 msgid "Select all dialogue lines"
-msgstr "Wähle alle Dialogzeilen aus"
+msgstr "Alle Dialogzeilen auswählen"
 
 #: ../src/command/subtitle.cpp:410 ../src/command/subtitle.cpp:411
 msgid "Select Visible"
 msgstr "Sichtbare auswählen"
 
 #: ../src/command/subtitle.cpp:412
-#, fuzzy
 msgid "Select all dialogue lines that are visible on the current video frame"
-msgstr "Wählt alle Zeilen aus, die im aktuellen Videoframe sichtbar sind"
+msgstr "Wähle alle Zeilen aus, die im aktuellen Videoframe sichtbar sind"
 
 #: ../src/command/subtitle.cpp:442
 msgid "Spell &Checker..."
@@ -1906,11 +1872,8 @@ msgid "Change End"
 msgstr "Ändere Ende"
 
 #: ../src/command/time.cpp:108
-#, fuzzy
 msgid "Change end times of lines to the next line's start time"
-msgstr ""
-"Ändert die Untertitelzeit so, daß die Endzeit auf die Anfangszeit des "
-"nächsten gesetzt wird"
+msgstr "Setze die Endzeit der Zeilen auf den Anfang der jeweiligen Folgezeile"
 
 #: ../src/command/time.cpp:117
 msgid "Change &Start"
@@ -1921,11 +1884,9 @@ msgid "Change Start"
 msgstr "Ändere Anfang"
 
 #: ../src/command/time.cpp:119
-#, fuzzy
 msgid "Change start times of lines to the previous line's end time"
 msgstr ""
-"Ändert die Untertitelzeit so, daß die Anfangszeit auf die Endzeit des "
-"vorigen gesetzt wird"
+"Setze den Startzeit der Zeilen auf das Ende der jeweiligen Vorgängerzeile"
 
 #: ../src/command/time.cpp:129
 msgid "Shift to &Current Frame"
@@ -1938,7 +1899,7 @@ msgstr "Verschiebe auf aktuellen Frame"
 #: ../src/command/time.cpp:131
 msgid "Shift selection so that the active line starts at current frame"
 msgstr ""
-"Verschiebt die ausgewählten Zeilen, so daß die erste ausgewählte Zeile beim "
+"Verschiebt die ausgewählten Zeilen, so dass die erste ausgewählte Zeile beim "
 "aktuellen Frame anfängt"
 
 #: ../src/command/time.cpp:147
@@ -1989,40 +1950,36 @@ msgid "snap to scene"
 msgstr "Auf Szene einrasten"
 
 #: ../src/command/time.cpp:241 ../src/command/time.cpp:242
-#, fuzzy
 msgid "Align subtitle to video"
-msgstr "Öffne Untertitel vom Video"
+msgstr "Untertitel am Video ausrichten"
 
 #: ../src/command/time.cpp:243
 msgid "Align subtitle to video by key points"
-msgstr ""
+msgstr "Untertitel mithilfe eines Markierungspunktes am Videobild ausrichten"
 
 #: ../src/command/time.cpp:252 ../src/command/time.cpp:253
 msgid "Add lead in and out"
 msgstr "Ein- und Auslaufbereiche hinzufügen"
 
 #: ../src/command/time.cpp:254
-#, fuzzy
 msgid "Add both lead in and out to the selected lines"
-msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+msgstr "Sowohl Ein- als auch Auslaufbereiche zu markierten Zeilen hinzufügen"
 
 #: ../src/command/time.cpp:266 ../src/command/time.cpp:267
 msgid "Add lead in"
 msgstr "Einlaufbereiche hinzufügen"
 
 #: ../src/command/time.cpp:268
-#, fuzzy
 msgid "Add the lead in time to the selected lines"
-msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+msgstr "Einlaufbereiche zu markierten Zeilen hinzufügen"
 
 #: ../src/command/time.cpp:278 ../src/command/time.cpp:279
 msgid "Add lead out"
 msgstr "Auslaufbereiche hinzufügen"
 
 #: ../src/command/time.cpp:280
-#, fuzzy
 msgid "Add the lead out time to the selected lines"
-msgstr "Erzeuge einen Audioclip für die ausgewählte Zeile"
+msgstr "Auslaufbreiche zu markierten Zeilen hinzufügen"
 
 #: ../src/command/time.cpp:289 ../src/command/time.cpp:290
 msgid "Increase length"
@@ -2104,9 +2061,8 @@ msgid "Close Timecodes File"
 msgstr "Zeitcode-Datei schließen"
 
 #: ../src/command/timecode.cpp:54
-#, fuzzy
 msgid "Close the currently open timecodes file"
-msgstr "Schließt die derzeit offene Datei mit Zeitcodes"
+msgstr "Schließe die derzeit offene Zeitcode-Datei"
 
 #: ../src/command/timecode.cpp:69
 msgid "Open Timecodes File..."
@@ -2114,25 +2070,23 @@ msgstr "Öffne Zeitcode-Datei..."
 
 #: ../src/command/timecode.cpp:70 ../src/command/timecode.cpp:75
 msgid "Open Timecodes File"
-msgstr "Öffne Zeitcode-Datei..."
+msgstr "Öffne Zeitcode-Datei"
 
 #: ../src/command/timecode.cpp:71
-#, fuzzy
 msgid "Open a VFR timecodes v1 or v2 file"
-msgstr "Öffnet eine Datei mit vfr-Zeitcodes, Typ v1 oder v2"
+msgstr "Öffne eine Datei mit VFR-Zeitcodes, Typ v1 oder v2"
 
 #: ../src/command/timecode.cpp:84
 msgid "Save Timecodes File..."
-msgstr "Speichere Zeitcode-Datei"
+msgstr "Speichere Zeitcode-Datei..."
 
 #: ../src/command/timecode.cpp:85 ../src/command/timecode.cpp:95
 msgid "Save Timecodes File"
 msgstr "Speichere Zeitcode-Datei"
 
 #: ../src/command/timecode.cpp:86
-#, fuzzy
 msgid "Save a VFR timecodes v2 file"
-msgstr "Speichere eine Datei mit vfr-Timecodes, Typ v2"
+msgstr "Speichere eine VFR-Zeitcode-Datei, Typ v2"
 
 #: ../src/command/tool.cpp:58
 msgid "ASSDraw3..."
@@ -2143,9 +2097,8 @@ msgid "ASSDraw3"
 msgstr "AssDraw3"
 
 #: ../src/command/tool.cpp:60
-#, fuzzy
 msgid "Launch the ASSDraw3 tool for vector drawing"
-msgstr "Startet das AssDraw3-Werkzeug für Vektorgrafik"
+msgstr "Starte das AssDraw3-Werkzeug für Vektorgrafiken"
 
 #: ../src/command/tool.cpp:70
 msgid "&Export Subtitles..."
@@ -2153,14 +2106,15 @@ msgstr "Exportiere Untertitel..."
 
 #: ../src/command/tool.cpp:71
 msgid "Export Subtitles"
-msgstr "Exportiere Untertitel..."
+msgstr "Exportiere Untertitel"
 
 #: ../src/command/tool.cpp:72
-#, fuzzy
 msgid ""
 "Save a copy of subtitles in a different format or with processing applied to "
 "it"
-msgstr "Speichert eine nachbearbeitete Kopie der Untertitel"
+msgstr ""
+"Speicher eine Kopie der Untertitel in aufbereiteter Form oder einem anderen "
+"Format"
 
 #: ../src/command/tool.cpp:83
 msgid "&Fonts Collector..."
@@ -2183,9 +2137,8 @@ msgid "Select Lines"
 msgstr "Zeilen auswählen"
 
 #: ../src/command/tool.cpp:97
-#, fuzzy
 msgid "Select lines based on defined criteria"
-msgstr "Wählt Zeilen nach bestimmten Kriterien aus"
+msgstr "Wähle Zeilen nach diversen Kriterien aus"
 
 #: ../src/command/tool.cpp:107
 msgid "&Resample Resolution..."
@@ -2200,6 +2153,8 @@ msgid ""
 "Resample subtitles to maintain their current appearance at a different "
 "script resolution"
 msgstr ""
+"Skaliere die Untertitel auf eine neue Skriptauflösung unter Beibehaltung des "
+"momentanen Aussehens"
 
 #: ../src/command/tool.cpp:122
 msgid "St&yling Assistant..."
@@ -2248,7 +2203,6 @@ msgid "Styles Manager"
 msgstr "Stil-Manager"
 
 #: ../src/command/tool.cpp:166
-#, fuzzy
 msgid "Open the styles manager"
 msgstr "Öffnet den Stil-Manager"
 
@@ -2260,10 +2214,11 @@ msgstr "Kanji-Timer..."
 msgid "Kanji Timer"
 msgstr "Kanji-Timer"
 
+# Wird scheinbar nirgends sonst “Kanji timer copier” gennant, sondern schlicht “Kanji timer”.
+# Im Deutschen das “copier” einfach unter den Tisch fallen lassen ?
 #: ../src/command/tool.cpp:178
-#, fuzzy
 msgid "Open the Kanji timer copier"
-msgstr "Öffne Kanji-Timer"
+msgstr "Öffne den Kanji-Timer"
 
 #: ../src/command/tool.cpp:188
 msgid "&Timing Post-Processor..."
@@ -2274,13 +2229,12 @@ msgid "Timing Post-Processor"
 msgstr "Timingnachbearbeitung"
 
 #: ../src/command/tool.cpp:190
-#, fuzzy
 msgid ""
 "Post-process the subtitle timing to add lead-ins and lead-outs, snap timing "
 "to scene changes, etc."
 msgstr ""
-"Startet eine Timingnachbearbeitung, die Einlaufbereiche, Auslaufbereiche, "
-"Szenen-Timing usw. übernimmt."
+"Starte eine Timingnachbearbeitung, um Ein- und Auslaufbereiche hinzuzufügen, "
+"Timing auf Keyframes abzustimmen uvm."
 
 #: ../src/command/tool.cpp:200
 msgid "&Translation Assistant..."
@@ -2332,9 +2286,8 @@ msgid "Cinematic (2.35)"
 msgstr "Kinoformat (2.35)"
 
 #: ../src/command/video.cpp:86
-#, fuzzy
 msgid "Force video to 2.35 aspect ratio"
-msgstr "Erzwingt 2.35:1-Seitenverhältnis für das Video"
+msgstr "Zwinge Video ins 47:20-„Kinoformat“ (2.35)"
 
 #: ../src/command/video.cpp:102
 msgid "C&ustom..."
@@ -2342,12 +2295,11 @@ msgstr "Benutzerdefiniert..."
 
 #: ../src/command/video.cpp:103
 msgid "Custom"
-msgstr "Benutzerdefiniert..."
+msgstr "Benutzerdefiniert"
 
 #: ../src/command/video.cpp:104
-#, fuzzy
 msgid "Force video to a custom aspect ratio"
-msgstr "Erzwingt ein benutzerdefiniertes Seitenverhältnis"
+msgstr "Erzwinge ein benutzerdefiniertes Seitenverhältnis"
 
 #: ../src/command/video.cpp:115
 msgid ""
@@ -2371,16 +2323,15 @@ msgstr "Ungültiges Seitenverhältnis"
 
 #: ../src/command/video.cpp:135
 msgid "Invalid value! Aspect ratio must be between 0.5 and 5.0."
-msgstr "Ungültiger Wert! Seitenverhältnis muß zwischen 0.5 und 5.0 liegen."
+msgstr "Ungültiger Wert! Seitenverhältnis muss zwischen 0.5 und 5.0 liegen."
 
 #: ../src/command/video.cpp:145
 msgid "&Default"
 msgstr "Vorgabe"
 
 #: ../src/command/video.cpp:147
-#, fuzzy
 msgid "Use video's original aspect ratio"
-msgstr "Beläßt das ursprüngliche Seitenverhältnis des Videos"
+msgstr "Verwende ursprüngliches Seitenverhältnis des Videos"
 
 #: ../src/command/video.cpp:163
 msgid "&Fullscreen (4:3)"
@@ -2391,9 +2342,8 @@ msgid "Fullscreen (4:3)"
 msgstr "&Vollbildformat (4:3)"
 
 #: ../src/command/video.cpp:165
-#, fuzzy
 msgid "Force video to 4:3 aspect ratio"
-msgstr "Erzwingt 4:3-Seitenverhältnis für das Video"
+msgstr "Zwinge das Video ins 4:3-Format"
 
 #: ../src/command/video.cpp:181
 msgid "&Widescreen (16:9)"
@@ -2404,9 +2354,8 @@ msgid "Widescreen (16:9)"
 msgstr "&Breitbildformat (16:9)"
 
 #: ../src/command/video.cpp:183
-#, fuzzy
 msgid "Force video to 16:9 aspect ratio"
-msgstr "Erzwingt 19:9-Seitenverhältnis für das Video"
+msgstr "Zwinge das Video ins 16:9-Format"
 
 #: ../src/command/video.cpp:200
 msgid "&Close Video"
@@ -2417,9 +2366,8 @@ msgid "Close Video"
 msgstr "Video &schließen"
 
 #: ../src/command/video.cpp:202
-#, fuzzy
 msgid "Close the currently open video file"
-msgstr "Schließt die derzeit offene Videodatei"
+msgstr "Schließe die derzeit offene Videodatei"
 
 #: ../src/command/video.cpp:211 ../src/command/video.cpp:212
 msgid "Copy coordinates to Clipboard"
@@ -2433,18 +2381,17 @@ msgstr ""
 "Zwischenablage"
 
 #: ../src/command/video.cpp:222 ../src/command/video.cpp:223
-#, fuzzy
 msgid "Cycle active subtitles provider"
-msgstr "Untertitel-Provider"
+msgstr "Wechsle Untertitel-Provider durch"
 
 #: ../src/command/video.cpp:224
 msgid "Cycle through the available subtitles providers"
-msgstr ""
+msgstr "Wechsle zyklisch durch die verfügbaren Untertitel-Provider"
 
 #: ../src/command/video.cpp:235
-#, fuzzy, c-format
+#, c-format
 msgid "Subtitles provider set to %s"
-msgstr "Untertitel-Provider"
+msgstr "Untertitel-Provider %s gewählt"
 
 #: ../src/command/video.cpp:242
 msgid "&Detach Video"
@@ -2455,7 +2402,6 @@ msgid "Detach Video"
 msgstr "Video abkoppeln"
 
 #: ../src/command/video.cpp:244
-#, fuzzy
 msgid ""
 "Detach the video display from the main window, displaying it in a separate "
 "Window"
@@ -2465,26 +2411,25 @@ msgstr ""
 
 #: ../src/command/video.cpp:262
 msgid "Show &Video Details"
-msgstr "Zeige Videodetails..."
+msgstr "Zeige &Videodetails"
 
 #: ../src/command/video.cpp:263
 msgid "Show Video Details"
-msgstr "Zeige Videodetails..."
+msgstr "Zeige Videodetails"
 
 #: ../src/command/video.cpp:264
-#, fuzzy
 msgid "Show video details"
-msgstr "Zeigt die Videodetails an"
+msgstr "Zeige die Videodetails an"
 
 #: ../src/command/video.cpp:274 ../src/command/video.cpp:275
 msgid "Toggle video slider focus"
 msgstr "Wechsle Video-Schieberegeler"
 
 #: ../src/command/video.cpp:276
-#, fuzzy
 msgid ""
 "Toggle focus between the video slider and the previous thing to have focus"
-msgstr "Wechsle Fokus zwischen dem Videoschieberegler und anderen sachen"
+msgstr ""
+"Wechsle Fokus zwischen dem Videoschieberegler und dem vorigem/aktuellen Fokus"
 
 #: ../src/command/video.cpp:297 ../src/command/video.cpp:298
 msgid "Copy image to Clipboard"
@@ -2517,7 +2462,6 @@ msgid "Next Boundary"
 msgstr "Nächste Grenze"
 
 #: ../src/command/video.cpp:332
-#, fuzzy
 msgid "Seek to the next beginning or end of a subtitle"
 msgstr "Springe zur nächsten Untertitelgrenze"
 
@@ -2547,7 +2491,6 @@ msgid "Previous Boundary"
 msgstr "Vorherige Grenze"
 
 #: ../src/command/video.cpp:399
-#, fuzzy
 msgid "Seek to the previous beginning or end of a subtitle"
 msgstr "Springe zur vorherigen Untertitelgrenze"
 
@@ -2607,7 +2550,6 @@ msgid "Jump Video to End"
 msgstr "Video: ans Ende springen"
 
 #: ../src/command/video.cpp:538
-#, fuzzy
 msgid "Jump the video to the end frame of current subtitle"
 msgstr "Springt mit dem Video zum Ende des aktuellen Untertitels"
 
@@ -2620,7 +2562,6 @@ msgid "Jump Video to Start"
 msgstr "Video: an den Anfang springen"
 
 #: ../src/command/video.cpp:551
-#, fuzzy
 msgid "Jump the video to the start frame of current subtitle"
 msgstr "Springt mit dem Video zum Anfang des aktuellen Untertitels"
 
@@ -2633,9 +2574,8 @@ msgid "Open Video"
 msgstr "Öffne Video"
 
 #: ../src/command/video.cpp:564
-#, fuzzy
 msgid "Open a video file"
-msgstr "Öffnet eine Videodatei"
+msgstr "Öffne eine Videodatei"
 
 #: ../src/command/video.cpp:569
 msgid "Open video file"
@@ -2650,9 +2590,8 @@ msgid "Use Dummy Video"
 msgstr "Benutze Dummy-Video"
 
 #: ../src/command/video.cpp:580
-#, fuzzy
 msgid "Open a placeholder video clip with solid color"
-msgstr "Öffnet einen einfarbigen Videoclip"
+msgstr "Öffne einen einfarbigen Videoclip"
 
 #: ../src/command/video.cpp:592 ../src/command/video.cpp:593
 msgid "Toggle autoscroll of video"
@@ -2661,6 +2600,7 @@ msgstr "Automatisches Scrollen des Videos ein-/ausschalten"
 #: ../src/command/video.cpp:594
 msgid "Toggle automatically seeking video to the start time of selected lines"
 msgstr ""
+"Automatisches Scrollen des Videos zum Start der gewählten Zeile umschalten"
 
 #: ../src/command/video.cpp:609 ../src/command/video.cpp:610
 msgid "Play"
@@ -2826,67 +2766,68 @@ msgstr "Kompiliert von %s am %s."
 
 #: ../src/dialog_align.cpp:86
 msgid "Align subtitle to video by key point"
-msgstr ""
+msgstr "Untertitel durch Marker auf Videobild ausrichten"
 
 #: ../src/dialog_align.cpp:102 ../src/dialog_align.cpp:103
 #: ../src/dialog_align.cpp:113
 #, c-format
 msgid "%i"
-msgstr ""
+msgstr "%i"
 
 #: ../src/dialog_align.cpp:108
 msgid "The key color to be followed"
 msgstr ""
+"Indikatorfarbe; solange Farbwert in Toleranz bleibt werden die Untertitel "
+"angezeigt"
 
 #: ../src/dialog_align.cpp:110
 msgid "The x coord of the key point"
-msgstr ""
+msgstr "X-Koordinate des Markierungspunktes"
 
 #: ../src/dialog_align.cpp:112
 msgid "The y coord of the key point"
-msgstr ""
+msgstr "Y-Koordinate des Markierungspunktes"
 
 #: ../src/dialog_align.cpp:114
 msgid "Max tolerance of the color"
-msgstr ""
+msgstr "Maximale Farbtoleranz."
 
 #: ../src/dialog_align.cpp:121
 msgid "X"
-msgstr ""
+msgstr "X"
 
 #: ../src/dialog_align.cpp:122
 msgid "Y"
-msgstr ""
+msgstr "Y"
 
 #: ../src/dialog_align.cpp:123
-#, fuzzy
 msgid "Color"
-msgstr "Farben"
+msgstr "Farbe"
 
 #: ../src/dialog_align.cpp:124
 msgid "Tolerance"
-msgstr ""
+msgstr "Toleranz"
 
 #: ../src/dialog_align.cpp:265
 msgid "Bad x or y position or tolerance value!"
-msgstr ""
+msgstr "Ungültige Farb- oder Toleranzwerte (erwarte Ganzzahl) !"
 
 #: ../src/dialog_align.cpp:270
 #, c-format
 msgid "Bad x or y position! Require: 0 <= x < %i, 0 <= y < %i"
-msgstr ""
+msgstr "Ungültige x- oder y-Position! Erlaubt: 0 <= x < %i, 0 <= y < %i"
 
 #: ../src/dialog_align.cpp:275
 msgid "Bad tolerance value! Require: 0 <= torlerance <= 255"
-msgstr ""
+msgstr "Ungültiger Toleranzwert"
 
 #: ../src/dialog_align.cpp:297
 msgid "Selected position and color are not within tolerance!"
-msgstr ""
+msgstr "Gewählter Pixel und Farbwert liegen nicht innerhalb der Toleranz!"
 
 #: ../src/dialog_align.cpp:325
 msgid "Align to video by key point"
-msgstr ""
+msgstr "Durch Marker auf Videobild ausrichten"
 
 #: ../src/dialog_attachments.cpp:68
 msgid "Attachment List"
@@ -3088,35 +3029,35 @@ msgstr "Farbspektrum"
 
 #: ../src/dialog_colorpicker.cpp:572
 msgid "HSL/L"
-msgstr "Hsl-L"
+msgstr "HSL-L"
 
 #: ../src/dialog_colorpicker.cpp:572
 msgid "HSV/H"
-msgstr "Hsv-H"
+msgstr "HSV-H"
 
 #: ../src/dialog_colorpicker.cpp:572
 msgid "RGB/B"
-msgstr "Rgb-B"
+msgstr "RGB-B"
 
 #: ../src/dialog_colorpicker.cpp:572
 msgid "RGB/G"
-msgstr "Rgb-G"
+msgstr "RGB-G"
 
 #: ../src/dialog_colorpicker.cpp:572
 msgid "RGB/R"
-msgstr "Rgb-R"
+msgstr "RGB-R"
 
 #: ../src/dialog_colorpicker.cpp:583
 msgid "RGB color"
-msgstr "Rgb-Farbschema"
+msgstr "RGB-Farbschema"
 
 #: ../src/dialog_colorpicker.cpp:584
 msgid "HSL color"
-msgstr "Hsl-Farbschema"
+msgstr "HSL-Farbschema"
 
 #: ../src/dialog_colorpicker.cpp:585
 msgid "HSV color"
-msgstr "Hsv-Farbschema"
+msgstr "HSV-Farbschema"
 
 #: ../src/dialog_colorpicker.cpp:618
 msgid "Spectrum mode:"
@@ -3229,7 +3170,7 @@ msgid ""
 "Time code offset in incorrect format. Ensure it is entered as four groups of "
 "two digits separated by colons."
 msgstr ""
-"Das Zeitcode-Offset ist in einem falschen Format. Stellen Sie sicher, daß "
+"Das Zeitcode-Offset ist in einem falschen Format. Stellen Sie sicher, dass "
 "sie vier Gruppen aus je zwei Zahlen, die durch Doppelpunkte getrennt sind, "
 "eingegeben haben."
 
@@ -3271,27 +3212,27 @@ msgstr "Out-Times sind eingeschlossen"
 
 #: ../src/dialog_export_ebu3264.cpp:121
 msgid "ISO 6937-2 (Latin/Western Europe)"
-msgstr "Iso 6937-2 (Latein/Westeuropäisch)"
+msgstr "ISO 6937-2 (Latein/Westeuropäisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:122
 msgid "ISO 8859-5 (Cyrillic)"
-msgstr "Iso 8859-5 (Kyrillisch)"
+msgstr "ISO 8859-5 (Kyrillisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:123
 msgid "ISO 8859-6 (Arabic)"
-msgstr "Iso 8859-6 (Arabisch)"
+msgstr "ISO 8859-6 (Arabisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:124
 msgid "ISO 8859-7 (Greek)"
-msgstr "Iso 8859-7 (Griechisch)"
+msgstr "ISO 8859-7 (Griechisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:125
 msgid "ISO 8859-8 (Hebrew)"
-msgstr "Iso 8859-8 (Hebräisch)"
+msgstr "ISO 8859-8 (Hebräisch)"
 
 #: ../src/dialog_export_ebu3264.cpp:126
 msgid "UTF-8 Unicode (non-standard)"
-msgstr "Utf-8 Unicode (Nicht-Standard)"
+msgstr "UTF-8 Unicode (Nicht-Standard)"
 
 #: ../src/dialog_export_ebu3264.cpp:128
 msgid "Text encoding"
@@ -3299,7 +3240,7 @@ msgstr "Text-Kodierung"
 
 #: ../src/dialog_export_ebu3264.cpp:131
 msgid "Automatically wrap long lines (ASS)"
-msgstr "Automatisch lange Zeilen umbrechen (ass)"
+msgstr "Automatisch lange Zeilen umbrechen (ASS)"
 
 #: ../src/dialog_export_ebu3264.cpp:132
 msgid "Automatically wrap long lines (Balanced)"
@@ -3362,14 +3303,14 @@ msgid "Copying fonts to archive...\n"
 msgstr "Kopiere Schriftarten in Archiv...\n"
 
 #: ../src/dialog_fonts_collector.cpp:131
-#, fuzzy, c-format
+#, c-format
 msgid "* Failed to create directory '%s': %s.\n"
-msgstr "* Kopieren fehlgeschlagen: %s\n"
+msgstr "* Nicht möglich Ordner '%s' zu erstellen: %s.\n"
 
 #: ../src/dialog_fonts_collector.cpp:142
-#, fuzzy, c-format
+#, c-format
 msgid "* Failed to open %s.\n"
-msgstr "* Kopieren fehlgeschlagen: %s\n"
+msgstr "* Öffnen von %s fehlgeschlagen.\n"
 
 #: ../src/dialog_fonts_collector.cpp:197
 #, c-format
@@ -3467,7 +3408,7 @@ msgstr "Kann Zielordner nicht anlegen."
 
 #: ../src/dialog_fonts_collector.cpp:317
 msgid "Invalid path for .zip file."
-msgstr "Ungültiger Pfad für .zip-Datei"
+msgstr "Ungültiger Pfad für .zip-Datei."
 
 #: ../src/dialog_fonts_collector.cpp:341
 msgid "Select archive file name"
@@ -3508,11 +3449,11 @@ msgstr "Zeit: "
 
 #: ../src/dialog_kara_timing_copy.cpp:57
 msgid "Source: "
-msgstr "Quelle:"
+msgstr "Quelle: "
 
 #: ../src/dialog_kara_timing_copy.cpp:58
 msgid "Dest: "
-msgstr "Ziel:"
+msgstr "Ziel: "
 
 #: ../src/dialog_kara_timing_copy.cpp:470
 msgid "Kanji timing"
@@ -3616,7 +3557,6 @@ msgid "Please select the fields that you want to paste over:"
 msgstr "Bitte wählen Sie die Felder, die Sie überschreiben möchten:"
 
 #: ../src/dialog_paste_over.cpp:63
-#, fuzzy
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -3733,7 +3673,7 @@ msgstr "3: Intelligent umbrechen, untere Zeile ist breiter"
 
 #: ../src/dialog_properties.cpp:156
 msgid "Wrap Style: "
-msgstr "Umbruch-Stil:"
+msgstr "Umbruch-Stil: "
 
 #: ../src/dialog_properties.cpp:159
 msgid "Scale Border and Shadow"
@@ -3757,30 +3697,28 @@ msgid "&Symmetrical"
 msgstr "Symmetrisch"
 
 #: ../src/dialog_resample.cpp:143
-#, fuzzy
 msgid "From s&cript"
-msgstr "Keine Skripte"
+msgstr "Vom S&kript"
 
 #: ../src/dialog_resample.cpp:146
 msgid "Add borders"
-msgstr ""
+msgstr "Ränder hinzufügen"
 
 #: ../src/dialog_resample.cpp:146
 msgid "Manual"
-msgstr ""
+msgstr "Manuell"
 
 #: ../src/dialog_resample.cpp:146
-#, fuzzy
 msgid "Remove borders"
-msgstr "Entfernen"
+msgstr "Ränder entfernen"
 
 #: ../src/dialog_resample.cpp:146
 msgid "Stretch"
-msgstr ""
+msgstr "Strecken"
 
 #: ../src/dialog_resample.cpp:147
 msgid "Aspect Ratio Handling"
-msgstr ""
+msgstr "Seitenverhältnisanpassung"
 
 #: ../src/dialog_resample.cpp:162
 msgid "Margin offset"
@@ -3792,17 +3730,15 @@ msgstr "x"
 
 #: ../src/dialog_resample.cpp:172 ../src/dialog_resample.cpp:186
 msgid "YCbCr Matrix:"
-msgstr ""
+msgstr "YCbCr Farbmatrix:"
 
 #: ../src/dialog_resample.cpp:175
-#, fuzzy
 msgid "Source Resolution"
-msgstr "Skriptauflösung"
+msgstr "Quellauflösung"
 
 #: ../src/dialog_resample.cpp:189
-#, fuzzy
 msgid "Destination Resolution"
-msgstr "Auflösung anpassen"
+msgstr "Zielauflösung"
 
 #: ../src/dialog_search_replace.cpp:46
 msgid "Replace"
@@ -3837,23 +3773,20 @@ msgid "&Text"
 msgstr "Text"
 
 #: ../src/dialog_search_replace.cpp:87
-#, fuzzy
 msgid "A&ctor"
-msgstr "Sprecher"
+msgstr "Sp&recher"
 
 #: ../src/dialog_search_replace.cpp:87
-#, fuzzy
 msgid "St&yle"
-msgstr "Stilname"
+msgstr "St&ilname"
 
 #: ../src/dialog_search_replace.cpp:88
-#, fuzzy
 msgid "A&ll rows"
-msgstr "Alle Zeilen"
+msgstr "Alle Reihen"
 
 #: ../src/dialog_search_replace.cpp:88 ../src/dialog_shift_times.cpp:164
 msgid "Selected &rows"
-msgstr "Ausgewählte Zeilen"
+msgstr "Ausgewählte Reihen"
 
 #: ../src/dialog_search_replace.cpp:90 ../src/dialog_selection.cpp:138
 msgid "In Field"
@@ -3952,33 +3885,33 @@ msgid "Set se&lection"
 msgstr "Auswahl setzen"
 
 #: ../src/dialog_selection.cpp:212
-#, fuzzy, c-format
+#, c-format
 msgid "Selection was set to one line"
 msgid_plural "Selection was set to %u lines"
 msgstr[0] "Es wurde eine Zeile ausgewählt"
-msgstr[1] "Es wurde eine Zeile ausgewählt"
+msgstr[1] "Es wurden %u Zeilen ausgewählt"
 
 #: ../src/dialog_selection.cpp:213
 msgid "Selection was set to no lines"
 msgstr "Es wurde keine Zeile ausgewählt"
 
 #: ../src/dialog_selection.cpp:219
-#, fuzzy, c-format
+#, c-format
 msgid "One line was added to selection"
 msgid_plural "%u lines were added to selection"
 msgstr[0] "Eine Zeile wurde zur Auswahl hinzugefügt"
-msgstr[1] "Eine Zeile wurde zur Auswahl hinzugefügt"
+msgstr[1] "%u Zeilen wurden zur Auswahl hinzugefügt"
 
 #: ../src/dialog_selection.cpp:220
 msgid "No lines were added to selection"
 msgstr "Keine Zeile wurde zur Auswahl hinzugefügt"
 
 #: ../src/dialog_selection.cpp:231
-#, fuzzy, c-format
+#, c-format
 msgid "One line was removed from selection"
 msgid_plural "%u lines were removed from selection"
 msgstr[0] "Eine Zeile wurde aus der Auswahl entfernt"
-msgstr[1] "Eine Zeile wurde aus der Auswahl entfernt"
+msgstr[1] "%u Zeilen wurden aus der Auswahl entfernt"
 
 #: ../src/dialog_selection.cpp:232
 msgid "No lines were removed from selection"
@@ -4024,11 +3957,11 @@ msgstr "Alle"
 #: ../src/dialog_shift_times.cpp:114
 #, c-format
 msgid "from %d onward"
-msgstr "ab %d "
+msgstr "ab %d"
 
 #: ../src/dialog_shift_times.cpp:117
 msgid "sel "
-msgstr "Ausw."
+msgstr "Ausw. "
 
 #: ../src/dialog_shift_times.cpp:144
 msgid "&Time: "
@@ -4062,7 +3995,7 @@ msgstr "Vorwärts"
 msgid ""
 "Shifts subs forward, making them appear later. Use if they are appearing too "
 "soon."
-msgstr "Untertitel vorwärts verschieben, sodaß sie später angezeigt werden."
+msgstr "Untertitel vorwärts verschieben, sodass sie später angezeigt werden."
 
 #: ../src/dialog_shift_times.cpp:161
 msgid "&Backward"
@@ -4072,7 +4005,7 @@ msgstr "Rückwärts"
 msgid ""
 "Shifts subs backward, making them appear earlier. Use if they are appearing "
 "too late."
-msgstr "Untertitel rückwärts verschieben, sodaß sie früher angezeigt werden."
+msgstr "Untertitel rückwärts verschieben, sodass sie früher angezeigt werden."
 
 #: ../src/dialog_shift_times.cpp:164
 msgid "&All rows"
@@ -4152,7 +4085,7 @@ msgstr "Aegisub hat die Rechtschreibprüfung für dieses Skript abgeschlossen."
 
 #: ../src/dialog_spellchecker.cpp:279 ../src/dialog_spellchecker.cpp:283
 msgid "Spell checking complete."
-msgstr "&Rechtschreibprüfung abgeschlossen"
+msgstr "&Rechtschreibprüfung abgeschlossen."
 
 #: ../src/dialog_spellchecker.cpp:283
 msgid "Aegisub has found no spelling mistakes in this script."
@@ -4287,8 +4220,8 @@ msgid ""
 "Encoding, only useful in unicode if the font doesn't have the proper unicode "
 "mapping"
 msgstr ""
-"Kodierung, nur sinnvoll im Unicode, falls die Schriftart keine richtigen "
-"Unicode-Tabellen besitzt."
+"Kodierung (nur sinnvoll im Unicode, falls die Schriftart keine richtigen "
+"Unicode-Tabellen besitzt)"
 
 #: ../src/dialog_style_editor.cpp:239
 msgid "Character spacing, in pixels"
@@ -4434,11 +4367,11 @@ msgid "Could not parse style"
 msgstr "Kann den Stil nicht lesen"
 
 #: ../src/dialog_style_manager.cpp:257
-#, fuzzy, c-format
+#, c-format
 msgid "Are you sure you want to delete this style?"
 msgid_plural "Are you sure you want to delete these %d styles?"
-msgstr[0] "Sind Sie sicher, daß Sie diesen Stil löschen wollen?"
-msgstr[1] "Sind Sie sicher, daß Sie diesen Stil löschen wollen?"
+msgstr[0] "Sind Sie sicher, dass Sie diesen Stil löschen wollen?"
+msgstr[1] "Sind Sie sicher, dass Sie diese %d Stile löschen wollen?"
 
 #: ../src/dialog_style_manager.cpp:282
 msgid "Catalog of available storages"
@@ -4507,7 +4440,7 @@ msgstr "Ungültige Zeichen"
 #, c-format
 msgid "Are you sure you want to delete the storage \"%s\" from the catalog?"
 msgstr ""
-"Sind Sie sicher, daß Sie den Speicher \"%s\" aus dem Katalog löschen wollen?"
+"Sind Sie sicher, dass Sie den Speicher \"%s\" aus dem Katalog löschen wollen?"
 
 #: ../src/dialog_style_manager.cpp:500
 msgid "Confirm delete"
@@ -4705,7 +4638,7 @@ msgstr "Hinzuzufügende Einlaufbereiche in ms"
 
 #: ../src/dialog_timing_processor.cpp:181
 msgid "Add lead &out:"
-msgstr "Auslaufbereiche hinzufügen:"
+msgstr "Auslaufbereich hinzufügen:"
 
 #: ../src/dialog_timing_processor.cpp:183
 msgid "Enable adding of lead-outs to lines"
@@ -4798,7 +4731,7 @@ msgid ""
 "Threshold for 'before start' distance, that is, how many milliseconds a "
 "subtitle must start before a keyframe to snap to it"
 msgstr ""
-"Bereich für 'vor Anfang', d.h. wieviele Millisekunden ein Untertitel vor "
+"Bereich für 'vor Anfang', d.h. wie viele Millisekunden ein Untertitel vor "
 "einem Keyframe anfangen darf, um darauf einzurasten"
 
 #: ../src/dialog_timing_processor.cpp:232
@@ -4810,7 +4743,7 @@ msgid ""
 "Threshold for 'after start' distance, that is, how many milliseconds a "
 "subtitle must start after a keyframe to snap to it"
 msgstr ""
-"Bereich für 'nach Anfang', d.h. wieviele Millisekunden ein Untertitel nach "
+"Bereich für 'nach Anfang', d.h. wie viele Millisekunden ein Untertitel nach "
 "einem Keyframe anfangen darf, um darauf einzurasten"
 
 #: ../src/dialog_timing_processor.cpp:237
@@ -4822,7 +4755,7 @@ msgid ""
 "Threshold for 'before end' distance, that is, how many milliseconds a "
 "subtitle must end before a keyframe to snap to it"
 msgstr ""
-"Bereich für 'vor Ende', d.h. wieviele Millisekunden ein Untertitel vor einem "
+"Bereich für 'vor Ende', d.h. wie viele Millisekunden ein Untertitel vor einem "
 "Keyframe enden darf, um darauf einzurasten"
 
 #: ../src/dialog_timing_processor.cpp:240
@@ -4834,7 +4767,7 @@ msgid ""
 "Threshold for 'after end' distance, that is, how many milliseconds a "
 "subtitle must end after a keyframe to snap to it"
 msgstr ""
-"Bereich für 'nach Ende', d.h. wieviele Millisekunden ein Untertitel nach "
+"Bereich für 'nach Ende', d.h. wie viele Millisekunden ein Untertitel nach "
 "einem Keyframe enden darf, um darauf einzurasten"
 
 #: ../src/dialog_timing_processor.cpp:349
@@ -4906,7 +4839,7 @@ msgstr "Konnte nichts vom Update-Server herunterladen."
 #: ../src/dialog_version_check.cpp:311
 #, c-format
 msgid "HTTP request failed, got HTTP response %d."
-msgstr "http-Anforderung fehlgeschlagen, bekam http-Antwort %d"
+msgstr "HTTP-Anfrage mit Code %d fehlgeschlagen."
 
 #: ../src/dialog_version_check.cpp:342
 msgid "An update to Aegisub was found."
@@ -4942,12 +4875,13 @@ msgstr ""
 
 #: ../src/dialog_video_details.cpp:45
 msgid "Video Details"
-msgstr "Videodetails:"
+msgstr "Videodetails"
 
 #: ../src/dialog_video_details.cpp:59
 msgid "File name:"
 msgstr "Dateiname:"
 
+# Ja, im Deutschen wird fps kleingeschrieben
 #: ../src/dialog_video_details.cpp:60
 msgid "FPS:"
 msgstr "fps:"
@@ -4957,11 +4891,11 @@ msgid "Resolution:"
 msgstr "Auflösung:"
 
 #: ../src/dialog_video_details.cpp:62
-#, fuzzy, c-format
+#, c-format
 msgid "1 frame"
 msgid_plural "%d frames (%s)"
-msgstr[0] "%s Frames"
-msgstr[1] "%s Frames"
+msgstr[0] "1 Frame"
+msgstr[1] "%d Frames (%s)"
 
 #: ../src/dialog_video_details.cpp:62
 msgid "Length:"
@@ -4997,29 +4931,27 @@ msgstr ""
 "Videoauflösung:\t%d x %d\n"
 "Untertitelauflösung:\t%d x %d\n"
 "\n"
-"Untertitel-Auflösung anpassen, sodaß sie zum Video paßt?"
+"Untertitel-Auflösung anpassen, sodass sie zum Video passt?"
 
 #: ../src/dialog_video_properties.cpp:54 ../src/dialog_video_properties.cpp:63
-#, fuzzy
 msgid "Set to video resolution"
-msgstr "Videoauflösung:"
+msgstr "Auf Videoauflösung setzen"
 
 #: ../src/dialog_video_properties.cpp:55
 msgid "Resample script (stretch to new aspect ratio)"
-msgstr ""
+msgstr "Skript skalieren (auf neues Format strecken)"
 
 #: ../src/dialog_video_properties.cpp:56
 msgid "Resample script (add borders)"
-msgstr ""
+msgstr "Skript skalieren (Ränder hinzufügen)"
 
 #: ../src/dialog_video_properties.cpp:57
 msgid "Resample script (remove borders)"
-msgstr ""
+msgstr "Skript skalieren (Ränder entfernen)"
 
 #: ../src/dialog_video_properties.cpp:64
-#, fuzzy
 msgid "Resample script"
-msgstr "Auflösung anpassen"
+msgstr "Skript skalieren"
 
 #: ../src/dialog_video_properties.cpp:164
 msgid "change script resolution"
@@ -5057,7 +4989,7 @@ msgstr ""
 "Dies ist nützlich, um die regulären Untertitelzeiten in vfr-ac-"
 "Untertitelzeiten fürs Hardsubbing umzuwandeln.\n"
 "Dies kann auch dafür benutzt werden, um Untertitel in andere Video-"
-"Geschwindigkeiten zu konvertieren, wie z.B. Ntsc zu Pal."
+"Geschwindigkeiten zu konvertieren, wie z.B. NTSC zu PAL."
 
 #: ../src/export_framerate.cpp:92
 msgid "V&ariable"
@@ -5113,7 +5045,7 @@ msgstr "Wähle Videospur"
 #: ../src/font_file_lister.cpp:67
 #, c-format
 msgid "Style '%s' does not exist\n"
-msgstr ""
+msgstr "Stil '%s' existiert nicht\n"
 
 #: ../src/font_file_lister.cpp:154
 #, c-format
@@ -5128,12 +5060,12 @@ msgstr "'%s' in '%s' gefunden\n"
 #: ../src/font_file_lister.cpp:168
 #, c-format
 msgid "'%s' does not have a bold variant.\n"
-msgstr ""
+msgstr "Keine fette Variante für '%s' verfügbar.\n"
 
 #: ../src/font_file_lister.cpp:170
 #, c-format
 msgid "'%s' does not have an italic variant.\n"
-msgstr ""
+msgstr "Keine kursive Variante für '%s' verfügbar.\n"
 
 #: ../src/font_file_lister.cpp:174
 #, c-format
@@ -5174,19 +5106,19 @@ msgid "All fonts found.\n"
 msgstr "Fertig. Alle Schriftarten gefunden.\n"
 
 #: ../src/font_file_lister.cpp:230
-#, fuzzy, c-format
+#, c-format
 msgid "One font could not be found\n"
 msgid_plural "%d fonts could not be found.\n"
-msgstr[0] "%d Schriftarten konnten nicht gefunden werden.\n"
+msgstr[0] "Eine Schriftart konnte nicht gefunden werden.\n"
 msgstr[1] "%d Schriftarten konnten nicht gefunden werden.\n"
 
 #: ../src/font_file_lister.cpp:233
-#, fuzzy, c-format
+#, c-format
 msgid "One font was found, but was missing glyphs used in the script.\n"
 msgid_plural ""
 "%d fonts were found, but were missing glyphs used in the script.\n"
 msgstr[0] ""
-"%d Schriftarten wurden gefunden, aber es fehlen Zeichen, die im Skript "
+"Eine Schriftart wurde gefunden, aber es fehlen Zeichen, die im Skript "
 "benutzt werden.\n"
 msgstr[1] ""
 "%d Schriftarten wurden gefunden, aber es fehlen Zeichen, die im Skript "
@@ -5218,37 +5150,32 @@ msgid "End"
 msgstr "Ende"
 
 #: ../src/grid_column.cpp:264
-#, fuzzy
 msgid "Left Margin"
-msgstr "Ränder"
+msgstr "Linker Rand"
 
 #: ../src/grid_column.cpp:270
-#, fuzzy
 msgid "Right Margin"
-msgstr "Rechten Rand ändern"
+msgstr "Rechter Rand"
 
 #: ../src/grid_column.cpp:276
-#, fuzzy
 msgid "Vertical Margin"
-msgstr "Vertikalen Rand ändern"
+msgstr "Vertikaler Rand"
 
 #: ../src/grid_column.cpp:294
-#, fuzzy
 msgid "CPS"
-msgstr "fps"
+msgstr "CPS"
 
 #: ../src/grid_column.cpp:295
 msgid "Characters Per Second"
-msgstr ""
+msgstr "Zeichen pro Sekunde"
 
 #: ../src/hotkey.cpp:271
-#, fuzzy
 msgid "Invalid command name for hotkey"
-msgstr "'%s' ist kein gültiger Kommandoname"
+msgstr "Kommandoname nicht für Hotkeys gültig"
 
 #: ../src/main.cpp:88
 msgid "Aegisub startup log"
-msgstr ""
+msgstr "Aegisub Startlog"
 
 #: ../src/main.cpp:280
 #, c-format
@@ -5293,6 +5220,10 @@ msgid ""
 "\n"
 "Error Message: %s"
 msgstr ""
+"Entschuldigung, ein Fehler ist aufgetreten. Bitte speichern Sie Ihre Arbeit "
+"und starten Aegisub neu.\n"
+"\n"
+"Fehlermeldung: %s"
 
 #: ../src/menu.cpp:101
 msgid "Empty"
@@ -5308,7 +5239,7 @@ msgstr "Keine Automatisierungsmakros geladen"
 
 #: ../src/mkv_wrap.cpp:213
 msgid "Choose which track to read:"
-msgstr "Wählen Sie die Spur aus, den sie lesen wollen: "
+msgstr "Wählen Sie die Spur aus, den sie lesen wollen:"
 
 #: ../src/mkv_wrap.cpp:213
 msgid "Multiple subtitle tracks found"
@@ -5320,7 +5251,7 @@ msgstr "Analysiere Matroska"
 
 #: ../src/mkv_wrap.cpp:251
 msgid "Reading subtitles from Matroska file."
-msgstr "Lese Untertitel aus Matroska-Datei"
+msgstr "Lese Untertitel aus Matroska-Datei."
 
 #: ../src/preferences.cpp:62 ../src/preferences.cpp:64
 #: ../src/preferences.cpp:332 ../src/preferences.cpp:353
@@ -5336,9 +5267,8 @@ msgid "Show main toolbar"
 msgstr "Zeige Werkzeugleiste"
 
 #: ../src/preferences.cpp:67
-#, fuzzy
 msgid "Save UI state in subtitles files"
-msgstr "Untertiteldatei speichern"
+msgstr "UI-Status in Untertiteldatei speichern"
 
 #: ../src/preferences.cpp:71
 msgid "Toolbar Icon Size"
@@ -5373,14 +5303,12 @@ msgid "Find/Replace"
 msgstr "Suchen/Ersetzen"
 
 #: ../src/preferences.cpp:86
-#, fuzzy
 msgid "Default styles"
-msgstr "Stil einstellen"
+msgstr "Standardstile"
 
 #: ../src/preferences.cpp:88
-#, fuzzy
 msgid "Default style catalogs"
-msgstr "Standard Auslaufbereich-Länge (ms)"
+msgstr "Standard Stilkatalog"
 
 #: ../src/preferences.cpp:92
 msgid ""
@@ -5389,30 +5317,30 @@ msgid ""
 "\n"
 "You can set up style catalogs in the Style Manager."
 msgstr ""
+"Der gewählte Stilkatalog wird bei neuen oder aus Fremdformaten importierten "
+"Dateien verwendet.\n"
+"\n"
+"Sie können Stilkataloge im Stilmanager erstellen."
 
 #: ../src/preferences.cpp:117
-#, fuzzy
 msgid "New files"
-msgstr "&Neue Untertitel"
+msgstr "Neue Dateien"
 
 #: ../src/preferences.cpp:118
 msgid "MicroDVD import"
-msgstr ""
+msgstr "MicroDVD-Import"
 
 #: ../src/preferences.cpp:119
-#, fuzzy
 msgid "SRT import"
-msgstr "Stilimport"
+msgstr "SRT-Import"
 
 #: ../src/preferences.cpp:120
-#, fuzzy
 msgid "TTXT import"
-msgstr "Stilimport"
+msgstr "TTXT-Import"
 
 #: ../src/preferences.cpp:121
-#, fuzzy
 msgid "Plain text import"
-msgstr "Stilimport"
+msgstr "Reintext-Import"
 
 #: ../src/preferences.cpp:128 ../src/preferences.cpp:366
 msgid "Audio"
@@ -5436,7 +5364,7 @@ msgstr "Auto-Fokus, wenn der Mauszeiger darüber ist"
 
 #: ../src/preferences.cpp:135
 msgid "Play audio when stepping in video"
-msgstr "Audio abspielem im Video-Suchlauf"
+msgstr "Audio abspielen im Video-Suchlauf"
 
 #: ../src/preferences.cpp:136
 msgid "Left-click-drag moves end marker"
@@ -5569,12 +5497,13 @@ msgstr "Standardhöhe"
 
 #: ../src/preferences.cpp:198
 msgid "Always resample"
-msgstr ""
+msgstr "Immer skalieren"
 
+# "Always set" ist Option bei automatischer Skriptaufl.-Anpassung anhand des Videos.
+# Aus "Immer übernehmen" geht nicht hervor, dass keine Skalierung stattfindet.
 #: ../src/preferences.cpp:198
-#, fuzzy
 msgid "Always set"
-msgstr "Immer"
+msgstr "Vid-Aufl. übernehmen (ohne Skal.)"
 
 #: ../src/preferences.cpp:200
 msgid "Match video resolution on open"
@@ -5606,7 +5535,7 @@ msgstr "Wörterbuch-Ordner"
 
 #: ../src/preferences.cpp:217
 msgid "Character Counter"
-msgstr ""
+msgstr "Zeichenzähler"
 
 #: ../src/preferences.cpp:218
 msgid "Maximum characters per line"
@@ -5614,19 +5543,19 @@ msgstr "Maximale Zeichen pro Zeile"
 
 #: ../src/preferences.cpp:219
 msgid "Characters Per Second Warning Threshold"
-msgstr ""
+msgstr "Warngrenze für Zeichen pro Sekunde"
 
 #: ../src/preferences.cpp:220
 msgid "Characters Per Second Error Threshold"
-msgstr ""
+msgstr "Fehlergrenze für Zeichen pro Sekunde"
 
 #: ../src/preferences.cpp:221
 msgid "Ignore whitespace"
-msgstr ""
+msgstr "Ignoriere Leerraum"
 
 #: ../src/preferences.cpp:222
 msgid "Ignore punctuation"
-msgstr ""
+msgstr "Ignoriere Satzzeichen"
 
 #: ../src/preferences.cpp:224
 msgid "Grid"
@@ -5634,7 +5563,7 @@ msgstr "Untertitel-Gitter"
 
 #: ../src/preferences.cpp:225
 msgid "Focus grid on click"
-msgstr ""
+msgstr "Gitter bei Klick fokussieren"
 
 #: ../src/preferences.cpp:226
 msgid "Highlight visible subtitles"
@@ -5646,7 +5575,7 @@ msgstr "Symbol für nicht angezeigte Tags"
 
 #: ../src/preferences.cpp:231
 msgid "Skip over whitespace"
-msgstr ""
+msgstr "Leerzeichen überspringen"
 
 #: ../src/preferences.cpp:246
 msgid "Audio Display"
@@ -5677,22 +5606,20 @@ msgid "Syntax Highlighting"
 msgstr "Syntaxhervorhebung"
 
 #: ../src/preferences.cpp:255
-#, fuzzy
 msgid "Background"
-msgstr "Fehlermarkierung"
+msgstr "Hintergrund"
 
 #: ../src/preferences.cpp:256
 msgid "Normal"
 msgstr "Normal"
 
 #: ../src/preferences.cpp:257
-#, fuzzy
 msgid "Comments"
 msgstr "Kommentare"
 
 #: ../src/preferences.cpp:258
 msgid "Drawings"
-msgstr ""
+msgstr "Zeichnungen"
 
 #: ../src/preferences.cpp:259
 msgid "Brackets"
@@ -5723,9 +5650,8 @@ msgid "Karaoke templates"
 msgstr "Karaoke-Vorlage"
 
 #: ../src/preferences.cpp:267
-#, fuzzy
 msgid "Karaoke variables"
-msgstr "Karaoke-Vorlage"
+msgstr "Karaoke-Variablen"
 
 #: ../src/preferences.cpp:273
 msgid "Audio Color Schemes"
@@ -5792,43 +5718,37 @@ msgid "Lines"
 msgstr "Zeilen"
 
 #: ../src/preferences.cpp:291
-#, fuzzy
 msgid "CPS Error"
-msgstr "Fehler"
+msgstr "CPS Fehler"
 
 #: ../src/preferences.cpp:293
-#, fuzzy
 msgid "Visual Typesetting Tools"
-msgstr "Visuelles Typesetting"
+msgstr "Visuelle Typesetting Werkzeuge"
 
 #: ../src/preferences.cpp:294
-#, fuzzy
 msgid "Primary Lines"
-msgstr "Primär"
+msgstr "Primärlinien"
 
 #: ../src/preferences.cpp:295
-#, fuzzy
 msgid "Secondary Lines"
-msgstr "Sekundär"
+msgstr "Sekundärlinien"
 
 #: ../src/preferences.cpp:296
-#, fuzzy
 msgid "Primary Highlight"
-msgstr "Syntaxhervorhebung"
+msgstr "Primäre Hervorhebung"
 
 #: ../src/preferences.cpp:297
-#, fuzzy
 msgid "Secondary Highlight"
-msgstr "Syntaxhervorhebung"
+msgstr "Sekundäre Hervorhebung"
 
 #: ../src/preferences.cpp:300
-#, fuzzy
 msgid "Visual Typesetting Tools Alpha"
-msgstr "Visuelles Typesetting"
+msgstr "Visuelle Typesetting-Werkzeuge Alpha"
 
+# Einstellung, die festlegt wie stark der Bereich außerhalb von (i)clips abgedunkelt wird
 #: ../src/preferences.cpp:301
 msgid "Shaded Area"
-msgstr ""
+msgstr "Abdunklungsstärke"
 
 #: ../src/preferences.cpp:310
 msgid "Backup"
@@ -5957,7 +5877,7 @@ msgstr "Keine (Nicht empfohlen)"
 
 #: ../src/preferences.cpp:377
 msgid "RAM"
-msgstr "Ram"
+msgstr "RAM"
 
 #: ../src/preferences.cpp:379
 msgid "Cache type"
@@ -6017,7 +5937,7 @@ msgstr "Immer alle Tonspuren indexieren"
 
 #: ../src/preferences.cpp:406
 msgid "Downmix to 16bit mono audio"
-msgstr ""
+msgstr "Auf 16Bit Mono heruntermischen"
 
 #: ../src/preferences.cpp:411
 msgid "Portaudio device"
@@ -6025,7 +5945,7 @@ msgstr "Portaudio-Gerät"
 
 #: ../src/preferences.cpp:416
 msgid "OSS Device"
-msgstr "Oss-Gerät"
+msgstr "OSS-Gerät"
 
 #: ../src/preferences.cpp:427
 msgid "Buffer latency"
@@ -6097,7 +6017,7 @@ msgstr "Durchsuchen..."
 
 #: ../src/preferences_base.cpp:244
 msgid "Choose..."
-msgstr "Auswählen"
+msgstr "Auswählen..."
 
 #: ../src/preferences_base.cpp:252
 msgid "Font Size"
@@ -6108,44 +6028,40 @@ msgid "Do you want to load/unload the associated files?"
 msgstr "Wollen Sie die verknüpften Dateien laden/entladen?"
 
 #: ../src/project.cpp:199
-#, fuzzy, c-format
+#, c-format
 msgid "Load audio file: %s"
-msgstr "Audio laden"
+msgstr "Audio-Datei laden: %s"
 
 #: ../src/project.cpp:199
-#, fuzzy
 msgid "Unload audio"
-msgstr "Audio laden"
+msgstr "Audio entladen"
 
 #: ../src/project.cpp:201
-#, fuzzy, c-format
+#, c-format
 msgid "Load video file: %s"
-msgstr "Öffnet eine Videodatei"
+msgstr "Öffne Videodatei: %s"
 
 #: ../src/project.cpp:201
-#, fuzzy
 msgid "Unload video"
-msgstr "Video abspielen"
+msgstr "Video entladen"
 
 #: ../src/project.cpp:203
-#, fuzzy, c-format
+#, c-format
 msgid "Load timecodes file: %s"
-msgstr "Speichere Zeitcode-Datei"
+msgstr "Lade Zeitcode-Datei: %s"
 
 #: ../src/project.cpp:203
-#, fuzzy
 msgid "Unload timecodes"
-msgstr "Zeitcodes ersetzen?"
+msgstr "Zeitcodes entladen"
 
 #: ../src/project.cpp:205
-#, fuzzy, c-format
+#, c-format
 msgid "Load keyframes file: %s"
-msgstr "Speichere Keyframe-Datei"
+msgstr "Keyframe-Datei laden: %s"
 
 #: ../src/project.cpp:205
-#, fuzzy
 msgid "Unload keyframes"
-msgstr "Schließe Keyframe-Datei"
+msgstr "Keyframe-Datei entladen"
 
 #: ../src/project.cpp:207
 msgid "(Un)Load files?"
@@ -6153,7 +6069,7 @@ msgstr "Dateien (ent)laden?"
 
 #: ../src/project.cpp:256
 msgid "The audio file was not found: "
-msgstr ""
+msgstr "Die Audio-Datei konnte nicht gefunden werden: "
 
 #: ../src/project.cpp:264
 msgid ""
@@ -6162,6 +6078,10 @@ msgid ""
 "\n"
 "The following providers were tried:\n"
 msgstr ""
+"Keine der verfügbaren Audioprovider konnte etwas mit der gewählten Datei "
+"anfangen.\n"
+"\n"
+"Die folgenden Provider haben es versucht:\n"
 
 #: ../src/project.cpp:267
 msgid ""
@@ -6170,6 +6090,9 @@ msgid ""
 "\n"
 "The following providers were tried:\n"
 msgstr ""
+"Keiner der Audioprovider besitzt den notwendigen Codec für die gewählte "
+"Datei.\n"
+"Die folgenden Provider wurden versucht:\n"
 
 #: ../src/resolution_resampler.cpp:290
 msgid "resolution resampling"
@@ -6180,10 +6103,10 @@ msgid "replace"
 msgstr "Ersetzen"
 
 #: ../src/search_replace_engine.cpp:274
-#, fuzzy, c-format
+#, c-format
 msgid "One match was replaced."
 msgid_plural "%d matches were replaced."
-msgstr[0] "%i Vorkommen ersetzt."
+msgstr[0] "Ein Vorkommen ersetzt."
 msgstr[1] "%i Vorkommen ersetzt."
 
 #: ../src/search_replace_engine.cpp:277
@@ -6227,9 +6150,8 @@ msgid "Style for this line"
 msgstr "Stil für diese Zeile"
 
 #: ../src/subs_edit_box.cpp:124
-#, fuzzy
 msgid "Edit"
-msgstr "&Bearbeiten"
+msgstr "Bearbeiten"
 
 #: ../src/subs_edit_box.cpp:134
 msgid ""
@@ -6413,7 +6335,7 @@ msgstr "15.000 fps"
 
 #: ../src/subtitle_format.cpp:111
 msgid "23.976 FPS (Decimated NTSC)"
-msgstr "23.976 fps (Dezimiertes Ntsc)"
+msgstr "23.976 fps (Dezimiertes NTSC)"
 
 #: ../src/subtitle_format.cpp:112
 msgid "24.000 FPS (FILM)"
@@ -6421,15 +6343,15 @@ msgstr "24.000 fps (Film)"
 
 #: ../src/subtitle_format.cpp:113
 msgid "25.000 FPS (PAL)"
-msgstr "25.000 fps (Pal)"
+msgstr "25.000 fps (PAL)"
 
 #: ../src/subtitle_format.cpp:114
 msgid "29.970 FPS (NTSC)"
-msgstr "29.970 fps (Ntsc)"
+msgstr "29.970 fps (NTSC)"
 
 #: ../src/subtitle_format.cpp:116
 msgid "29.970 FPS (NTSC with SMPTE dropframe)"
-msgstr "29.970 fps (Ntsc mit Smpte-Frame)"
+msgstr "29.970 fps (NTSC mit Smpte-Frame)"
 
 #: ../src/subtitle_format.cpp:117
 msgid "30.000 FPS"
@@ -6437,11 +6359,11 @@ msgstr "30.000 fps"
 
 #: ../src/subtitle_format.cpp:118
 msgid "50.000 FPS (PAL x2)"
-msgstr "50.000 fps (Pal x2)"
+msgstr "50.000 fps (PAL x2)"
 
 #: ../src/subtitle_format.cpp:119
 msgid "59.940 FPS (NTSC x2)"
-msgstr "59.940 fps (Ntsc x2)"
+msgstr "59.940 fps (NTSC x2)"
 
 #: ../src/subtitle_format.cpp:120
 msgid "60.000 FPS"
@@ -6449,12 +6371,13 @@ msgstr "60.000 fps"
 
 #: ../src/subtitle_format.cpp:121
 msgid "119.880 FPS (NTSC x4)"
-msgstr "119.880 fps (Ntsc x4)"
+msgstr "119.880 fps (NTSC x4)"
 
 #: ../src/subtitle_format.cpp:122
 msgid "120.000 FPS"
 msgstr "120.000 fps"
 
+# Ja, im Deutschen wird fps kleingeschrieben
 #: ../src/subtitle_format.cpp:126
 msgid "FPS"
 msgstr "fps"
@@ -6478,7 +6401,7 @@ msgstr "Dies könnte ein paar Minuten dauern"
 
 #: ../src/video_box.cpp:57
 msgid "Seek video"
-msgstr "Springe im Video zu..."
+msgstr "Springe im Video zu"
 
 #: ../src/video_box.cpp:62
 msgid "Current frame time and number"
@@ -6568,6 +6491,8 @@ msgstr "Einen Kontrollpunkt entfernen"
 msgid ""
 "A free, cross-platform open source tool for creating and modifying subtitles"
 msgstr ""
+"Ein freies, quelloffenes, betriebssystemunabhängiges Werkzeug zum Erstellen "
+"und Verändern von Untertiteln"
 
 #: aegisub.appdata.xml:2
 msgid ""
@@ -6576,6 +6501,11 @@ msgid ""
 "audio, and features many powerful tools for styling them, including a built-"
 "in real-time video preview."
 msgstr ""
+"Aegisub ist ein freies, quelloffenes, betriebssystemunabhängiges Werkzeug "
+"zum Erstellen und Verändern von Untertiteln. Das Timen aufs Audio wird durch "
+"Aegisub besonders einfach gemacht und es beinhaltet weitreichende "
+"Möglichkeiten die Darstellung der Untertitel anzupassen und in einer "
+"Echtzeit Videovorschau zu begutachten."
 
 #: aegisub.appdata.xml:3
 msgid ""
@@ -6587,6 +6517,13 @@ msgid ""
 "unrelated to Aegisub) many vital functions, or were too buggy and/or "
 "unreliable to be really useful."
 msgstr ""
+"Aegisubs Entwicklung wurde mit dem Ziel begonnen, Typesettern – vor allem im "
+"Bereich der Anime-Fansubs – unnötige Plackerei zu ersparen. Damals fehlten "
+"anderen ASS-Editoren viele dafür hilfreiche Funktionen, oder sie waren zu "
+"verbuggt um wirklich sinnvoll eingesetzt werden zu können. Da deren "
+"Entwicklung in den meisten Fällen inzwischen eingestellt wurde, hat sich "
+"diesbezüglich nicht viel verändert (Bubblesub ist hier als positive Ausnahme "
+"hervorzuheben)."
 
 #: aegisub.appdata.xml:4
 msgid ""
@@ -6597,46 +6534,51 @@ msgid ""
 "for creating karaoke effects, Automation can now be used much else, "
 "including creating macros and various other convenient tools)."
 msgstr ""
+"Seitdem hat Aegisub neben Typesetting noch viele andere nützliche Funktionen "
+"fürs Timen, Übersetzen, und das generelle Bearbeiten der Untertitel "
+"dazugewonnen. Insbesondere die anfangs nur für Karaoke-Effekte gedachten "
+"Nutzerskripte haben sich als mächtiges Allzweckwerkzeug erwiesen; "
+"beispielsweise lassen sich damit Makros realisieren."
 
 #: aegisub.appdata.xml:5
 msgid "Some highlights of Aegisub:"
-msgstr ""
+msgstr "Besonders hervorzuheben wären:"
 
 #: aegisub.appdata.xml:6
 msgid "Simple and intuitive yet powerful interface for editing subtitles"
-msgstr ""
+msgstr "Leicht verständliches aber mächtiges Interface"
 
 #: aegisub.appdata.xml:7
 msgid "Support for many formats and character sets"
-msgstr ""
+msgstr "Unterstützung für viele Formate und Zeichensätze"
 
 #: aegisub.appdata.xml:8
 msgid "Powerful video mode"
-msgstr ""
+msgstr "Mächtige Videotools"
 
 #: aegisub.appdata.xml:9
 msgid "Visual typesetting tools"
-msgstr ""
+msgstr "Visuelle Typesettingwerkzeuge"
 
 #: aegisub.appdata.xml:10
 msgid "Intuitive and customizable audio timing mode"
-msgstr ""
+msgstr "Intuitiver und anpassbarer Audio-Timingmodus"
 
 #: aegisub.appdata.xml:11
 msgid "Fully scriptable through the Automation module"
-msgstr ""
+msgstr "Weitreichende Automatisierung & Anpassung durch externe Skripte"
 
 #: aegisub.appdata.xml:12
 msgid "Typesetting"
-msgstr ""
+msgstr "Typesetting"
 
 #: aegisub.appdata.xml:13
 msgid "Audio video"
-msgstr ""
+msgstr "Audio- und Videovorschau"
 
 #: aegisub.appdata.xml:14
 msgid "Audio timing"
-msgstr ""
+msgstr "Audio-Timing"
 
 #: default_hotkey.json:244:
 msgid "Subtitle Edit Box"
@@ -6691,7 +6633,6 @@ msgid "A&utomation"
 msgstr "Automatisierung"
 
 #: default_menu.json:0
-#, fuzzy
 msgid "Export As..."
 msgstr "Exportiere als..."
 
@@ -6724,14 +6665,12 @@ msgid "Make Times Continuous"
 msgstr "Zeiten kontinuierlich machen"
 
 #: default_menu.json:0
-#, fuzzy
 msgid "Open Recent"
-msgstr "Letzte Audiodatei öffnen"
+msgstr "Zuletzt geöffnet"
 
 #: default_menu.json:0
-#, fuzzy
 msgid "Open..."
-msgstr "Öffnen"
+msgstr "Öffnen..."
 
 #: default_menu.json:0
 msgid "Override &AR"
@@ -6739,12 +6678,11 @@ msgstr "Seitenverhältnis ändern"
 
 #: default_menu.json:0
 msgid "Save"
-msgstr ""
+msgstr "Speichern"
 
 #: default_menu.json:0
-#, fuzzy
 msgid "Save As..."
-msgstr "Speichere Keyframe-Datei..."
+msgstr "Speichern als..."
 
 #: default_menu.json:0
 msgid "Set &Zoom"
@@ -6763,21 +6701,20 @@ msgid "Vie&w"
 msgstr "&Ansicht"
 
 #: default_menu.json:0
-#, fuzzy
 msgid "Window"
-msgstr "Neues Fenster"
+msgstr "Fenster"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Automatically check for new versions of Aegisub"
-msgstr ""
+msgstr "Automatisch nach neuen Aegisub-Versionen suchen"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Create a start menu icon"
-msgstr ""
+msgstr "Startmenü-Icon anlegen"
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid "Installing runtime libraries..."
-msgstr ""
+msgstr "Laufzeit-Bibliotheken werden installiert..."
 
 #: packages/win_installer/fragment_strings.iss:1
 msgid ""
@@ -6787,11 +6724,18 @@ msgid ""
 "warranties of any kind are given either.%n%nSee the Aegisub website for "
 "information on obtaining the source code."
 msgstr ""
+"Dies wird Aegisub {#BUILD_GIT_VERSION_STRING} auf Ihrem Computer "
+"installieren.%n%nAegisub steht unter der GNU General Public License Version "
+"2. Das bedeutet unter anderem, dass Sie diese Anwendung für jeden Zweck "
+"kostenfrei verwenden können. Es besteht keine Garantie oder Gewährleistung "
+"jeglicher Art. Wollen Sie Derivate veröffentlichen so müssen diese ebenfalls "
+"unter GPL v2 oder einer kompatiblen Lizenz stehen. Insbesondere muss der "
+"Quellcode frei zugänglich sein.%n%nWeitere Informationen und den Quellcode "
+"finden Sie auf der Webseite."
 
 #: packages/win_installer/fragment_strings.iss:1
-#, fuzzy
 msgid "Update Checker:"
-msgstr "Rechtschreibprüfung"
+msgstr "Update-Sucher:"
 
 #~ msgid "Selected rows"
 #~ msgstr "Ausgewählte Zeilen"
@@ -6841,10 +6785,10 @@ msgstr "Rechtschreibprüfung"
 
 #, c-format
 #~ msgid "Are you sure you want to delete these %d styles?"
-#~ msgstr "Sind Sie sicher, daß Sie %d Stile löschen wollen?"
+#~ msgstr "Sind Sie sicher, dass Sie %d Stile löschen wollen?"
 
 #~ msgid "Changes resolution and modifies subtitles to conform to change"
-#~ msgstr "Verändert die Auflösung und paßt die Untertitel entsprechend an"
+#~ msgstr "Verändert die Auflösung und passt die Untertitel entsprechend an"
 
 #~ msgid "Closes the currently open keyframes list"
 #~ msgstr "Schließt die aktuelle Keyframe-Datei"


### PR DESCRIPTION
Translate missing strings, defuzz (mostly) and some corrections
(hopefully without introducing new errors), like:
 - non-matching `printf` format strings
 - discrepancy of '...' usage or not-usage in English and German
 - Ntsc → NTSC, and similar