### PR TITLE
Make using locally built minilua actually work

### DIFF
--- a/Makefile.inc.in
+++ b/Makefile.inc.in
@@ -132,5 +132,5 @@ BIN_MKDIR    = mkdir
 BIN_MKDIR_P  = mkdir -p
 BIN_ECHO     = echo
 BIN_TOUCH    = touch
-BIN_LUA      = $(abspath @LUA@)
+BIN_LUA      = $(abspath $(or $(shell which @LUA@), @LUA@))
 BIN_WX_CONFIG = @WX_CONFIG_PATH@

--- a/Makefile.inc.in
+++ b/Makefile.inc.in
@@ -132,5 +132,5 @@ BIN_MKDIR    = mkdir
 BIN_MKDIR_P  = mkdir -p
 BIN_ECHO     = echo
 BIN_TOUCH    = touch
-BIN_LUA      = @LUA@
+BIN_LUA      = $(abspath @LUA@)
 BIN_WX_CONFIG = @WX_CONFIG_PATH@

--- a/src/libresrc/Makefile
+++ b/src/libresrc/Makefile
@@ -11,18 +11,19 @@ resrc_OBJ := \
 $(resrc_OBJ): $(d)default_config.h $(d)bitmap.h $(d)default_config.cpp $(d)bitmap.cpp
 
 RESPACK := cd $(TOP)src/libresrc; $(BIN_LUA) $(TOP)tools/respack.lua
+RESPACK_DEPS := $(BIN_LUA) $(TOP)tools/respack.lua
 
 $(d)bitmap.cpp: $(d)bitmap.h
 $(d)default_config.cpp: $(d)default_config.h
 
-$(d)bitmap.h: $(TOP)tools/respack.lua $(d)../bitmaps/button
+$(d)bitmap.h: $(RESPACK_DEPS) $(d)../bitmaps/button
 	$(RESPACK) ../bitmaps/manifest.respack bitmap.cpp bitmap.h
 
 ifeq (yes, $(BUILD_DARWIN))
-$(d)default_config.h: $(TOP)tools/respack.lua $(d)*.json $(d)osx/*.json
+$(d)default_config.h: $(RESPACK_DEPS) $(d)*.json $(d)osx/*.json
 	$(RESPACK) manifest_osx.respack default_config.cpp default_config.h
 else
-$(d)default_config.h: $(TOP)tools/respack.lua $(d)*.json
+$(d)default_config.h: $(RESPACK_DEPS) $(d)*.json
 	$(RESPACK) manifest.respack default_config.cpp default_config.h
 endif
 


### PR DESCRIPTION
When Aegisub is configured to use bundled luajit, the makefiles contain provisions to execute lua build scripts using a vendored minilua binary. However, there are two things that prevent this from working:
- The path to the local minilua binary is given relative to the project root, which means it will become incorrect if it's used after changing into a subdirectory.
- The makefile recipes that depend on this binary don't declare that dependency, so it won't get built automatically.

This PR fixes both of these build issues.