### PR TITLE
configure.ac: Fix error when using dash as /bin/sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,10 @@ PKG_PROG_PKG_CONFIG([pkgconfig_required_version])
 # Developers only
 #################
 AC_MSG_CHECKING([for version])
-. $srcdir/build/version.sh "$srcdir"
+old=$@ # Store the old arguments
+set -- "$srcdir" # Allows version.sh to see $srcdir as argument.
+. $srcdir/build/version.sh
+set -- $old # Put the old arguments back.
 AC_MSG_RESULT([$BUILD_GIT_VERSION_STRING $VERSION_SOURCE])
 
 AC_MSG_CHECKING([for build date])


### PR DESCRIPTION
Apparently passing arguments to a script while also sourcing doesn't work in a POSIX shell like dash.
For example:

this doesn't work.

```
dash -c ". build/version.sh ."
```

To get it to work I had to use `set --` to modify the current script arguments before sourcing `version.sh`.
Like this:

```
dash -c "set -- '.'; . build/version.sh"
```

I also make sure to save the old `./configure` arguments before running `set -- "$srcdir"` and then restoring them after sourcing `version.sh`