### PR TITLE
Fix rendering with libass to match xy-VSFilter

### DIFF
--- a/src/subtitles_provider_libass.cpp
+++ b/src/subtitles_provider_libass.cpp
@@ -170,6 +170,8 @@ LibassSubtitlesProvider::~LibassSubtitlesProvider() {
 
 void LibassSubtitlesProvider::DrawSubtitles(VideoFrame &frame,double time) {
 	ass_set_frame_size(renderer(), frame.width, frame.height);
+	// Note: this relies on Aegisub always rendering at video storage res
+	ass_set_storage_size(renderer(), frame.width, frame.height);
 
 	ASS_Image* img = ass_render_frame(renderer(), ass_track, int(time * 1000), nullptr);
 

--- a/vendor/csri/backends/libass/libass_csri.c
+++ b/vendor/csri/backends/libass/libass_csri.c
@@ -105,6 +105,8 @@ int csri_request_fmt(csri_inst *inst, const struct csri_fmt *fmt)
 	if (!csri_is_rgb(fmt->pixfmt) || csri_has_alpha(fmt->pixfmt))
 		return -1;
 	ass_set_frame_size(inst->ass_renderer, fmt->width, fmt->height);
+	// Note: this relies on CSRI always rendering at video storage res
+	ass_set_storage_size(inst->ass_renderer, fmt->width, fmt->height);
 	return 0;
 }
 


### PR DESCRIPTION
Since ASS rendering depends on the storage size of the video libass
needs to know about it to render the subtitles correctly. If it isn't
told about the storage size libass uses the value from PlayRes{X,Y} as
a guess, but this isn't always correct.
With Aegisub currently always rendering at storage resolution
this ends up the same as the frame size.

---

I'm confident the “rendering size == storage size” assumption holds true for Aegisub’s subtitle preview. From a glance it also appears to hold true for Aegisub’s csri frontends for CLI and AviSynth, but I'm less confident about those two. However, since csri currently only gets one size: if it isn't correct, this should also affect VSFilter-based backends.

You can see the different rendering on the following sample. Load it into Aegisub *without resampling to video resolution* and switch between xy-VSFilter or vsfilter_textsub *(**not** VSFilterMod!)* and libass; without the patch the result differs, with the patch it will match.
```
[Script Info]
ScriptType: v4.00+
WrapStyle: 0
ScaledBorderAndShadow: yes
YCbCr Matrix: None
PlayResX: 640
PlayResY: 360

Video File: ?dummy:25.000000:40000:1920:1080:47:191:225:
Video Position: 39

[Aegisub Project Garbage]
Video File: ?dummy:25.000000:40000:1920:1080:47:191:225:
Video Position: 39

[V4+ Styles]
Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
Style: Default,DejaVu Sans,65,&H007F67D0,&H00187DC1,&H00000000,&H00D4AA86,-1,0,0,0,100,100,0,0,1,0.4,0,7,10,10,10,1

[Events]
Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
Dialogue: 0,0:00:00.00,0:00:06.99,Default,,0,0,0,,{\pos(52,72)\an7\1c&HB3B3B3&\fscx100\fscy100\p1}m 2 34 l 8 60 112 37 107 24
Dialogue: 0,0:00:00.00,0:00:06.99,Default,,0,0,0,,{\frx18\fry32}{\fs36\pos(53.7385,101.846)\frz2.645}Some Text in a Sign
```

A furhter example can be found in [Aegisub/Aegisub#269](https://github.com/Aegisub/Aegisub/issues/269), but this is also affected by another bug where Aegisub doesn't de-squeeze anamorphic content before display in the subtitle preview.

---

Corresponding merge request for TypesettingTools/Aegisub: https://github.com/TypesettingTools/Aegisub/pull/147